### PR TITLE
Fix worker matplotlib dep, S3 null bucket list, MinIO host ports

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -32,8 +32,8 @@ services:
       MINIO_ROOT_USER: ${MINIO_ROOT_USER:-minioadmin}
       MINIO_ROOT_PASSWORD: ${MINIO_ROOT_PASSWORD:-minioadmin}
     ports:
-      - "9000:9000"   # S3 API
-      - "9001:9001"   # console
+      - "9002:9000"   # S3 API   (host 9002 -> container 9000)
+      - "9003:9001"   # console   (host 9003 -> container 9001)
     volumes:
       - miniodata:/data
     healthcheck:

--- a/src/Diariz.Api/Services/AudioStorage.cs
+++ b/src/Diariz.Api/Services/AudioStorage.cs
@@ -29,7 +29,9 @@ public class AudioStorage : IAudioStorage
     public async Task EnsureBucketAsync(CancellationToken ct = default)
     {
         var buckets = await _s3.ListBucketsAsync(ct);
-        if (!buckets.Buckets.Any(b => b.BucketName == _opts.Bucket))
+        // AWS SDK v4 returns a null Buckets list (not an empty one) when none exist.
+        var exists = buckets.Buckets?.Any(b => b.BucketName == _opts.Bucket) ?? false;
+        if (!exists)
             await _s3.PutBucketAsync(_opts.Bucket, ct);
     }
 

--- a/src/Diariz.Worker/requirements.txt
+++ b/src/Diariz.Worker/requirements.txt
@@ -1,5 +1,6 @@
 # torch / torchaudio are installed from the CUDA wheel index in the Dockerfile.
 whisperx==3.3.1
+matplotlib==3.9.4
 redis==5.2.1
 boto3==1.35.99
 requests==2.32.3


### PR DESCRIPTION
Three fixes found during the first deploy of the Milestone 1 stack on Windows/Docker Desktop.

## Fixes

| Issue | Cause | Fix |
|---|---|---|
| **Worker** crashes: `No module named 'matplotlib'` | pyannote/whisperx import matplotlib but don't pin it as an explicit dependency | Add `matplotlib==3.9.4` to `requirements.txt` |
| **API** `ArgumentNullException (Parameter 'Source')` in `AudioStorage.EnsureBucketAsync` | AWS SDK for .NET v4 returns a **null** `Buckets` list (not empty) when the account has no buckets — i.e. fresh MinIO | Null-guard the `.Any()` check |
| **MinIO** host port conflicts (9000/9001) | Ports already in use on the deploy machine | Remap host ports to **9002** (S3 API) / **9003** (console); container stays on 9000/9001 so internal `minio:9000` references are unchanged |

## Verification
- `dotnet build` — 0 warnings / 0 errors.
- `docker compose config` — valid.
- Functional runtime verification happens on the GPU deploy machine (record a 2-speaker clip → diarized transcript).

## Follow-up (not in this PR)
`GET /api/recordings/{id}/audio-url` generates presigned URLs against the internal `http://minio:9000`, which a host browser can't resolve — affects in-app audio playback only, not capture→transcribe→view. A `Storage:PublicEndpoint` rewrite (e.g. `http://localhost:9002`) will address it when playback is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)