### PR TITLE
Fix audio upload 500: remove DisablePayloadSigning on MinIO PutObject

### DIFF
--- a/src/Diariz.Api/Services/AudioStorage.cs
+++ b/src/Diariz.Api/Services/AudioStorage.cs
@@ -42,8 +42,10 @@ public class AudioStorage : IAudioStorage
             BucketName = _opts.Bucket,
             Key = key,
             InputStream = content,
-            ContentType = contentType,
-            DisablePayloadSigning = true // required for MinIO over plain HTTP
+            ContentType = contentType
+            // NB: do NOT set DisablePayloadSigning here — AWS SDK v4 rejects it over
+            // plain HTTP ("must be sent over HTTPS"). Normal SigV4 payload signing works
+            // fine against MinIO over HTTP.
         }, ct);
     }
 


### PR DESCRIPTION
## Problem

Uploading a recording returned **500**, with this exception in the API log:

```
Amazon.Runtime.AmazonClientException: When DisablePayloadSigning is true, the request must be sent over HTTPS.
   at ...AudioStorage.UploadAsync(...) AudioStorage.cs:line 40
```

`UploadAsync` set `DisablePayloadSigning = true` on the `PutObjectRequest`. AWS SDK for .NET **v4** refuses to skip payload signing unless the connection is HTTPS, and MinIO is reached over plain HTTP (`http://minio:9000`). Bucket `ListBuckets`/`PutBucket` at startup succeeded because they carry no payload — only the first `PutObject` (the audio upload) tripped it.

## Fix

Remove the `DisablePayloadSigning` flag and let normal SigV4 payload signing run. That works correctly against MinIO over HTTP — no HTTPS required.

## Verification
- `dotnet build` — 0 warnings / 0 errors.
- Runtime: after rebuilding `api`, recording → stop should upload (201), create a `Recordings` row + a blob in the `recordings` MinIO bucket, and enqueue the transcription job.

## Follow-ups (separate, noted from this debugging session)
- `SeedDefaultUserAsync` swallows `CreateAsync` failures — should log success/failure (the seeded user silently never got created earlier).
- The web app shows a generic "Upload failed" / "Invalid email or password" for any error — should surface the real API message to avoid blind debugging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)