### PR TITLE
Surface real API errors in UI; log seed user outcome

### DIFF
--- a/apps/web/src/components/Recorder.tsx
+++ b/apps/web/src/components/Recorder.tsx
@@ -1,5 +1,5 @@
 import { useRef, useState } from "react";
-import { api } from "../lib/api";
+import { api, apiErrorMessage } from "../lib/api";
 import { getStream, isElectron, type AudioSourceKind } from "../lib/audioSource";
 
 export default function Recorder({ onUploaded }: { onUploaded: () => void }) {
@@ -55,8 +55,8 @@ export default function Recorder({ onUploaded }: { onUploaded: () => void }) {
       const title = `${source === "system" ? "System" : "Mic"} ${new Date().toLocaleString()}`;
       await api.upload(blob, title, durationMs);
       onUploaded();
-    } catch {
-      setError("Upload failed.");
+    } catch (e) {
+      setError(apiErrorMessage(e, "Upload failed."));
     } finally {
       setBusy(false);
     }

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -66,3 +66,22 @@ export const api = {
     return data.url;
   },
 };
+
+// Extract a human-readable message from an axios error. Understands the shapes the
+// API returns: plain strings (BadRequest("...")), Identity error arrays, and
+// ASP.NET ProblemDetails ({ title, errors }). Falls back gracefully.
+export function apiErrorMessage(e: unknown, fallback = "Something went wrong."): string {
+  if (axios.isAxiosError(e)) {
+    if (!e.response) return "Cannot reach the server.";
+    const data = e.response.data as any;
+    if (typeof data === "string" && data.trim()) return data;
+    if (Array.isArray(data) && data.length) return data.map(String).join(" ");
+    if (data?.errors) {
+      const msgs = Object.values(data.errors).flat();
+      if (msgs.length) return msgs.map(String).join(" ");
+    }
+    if (data?.title) return data.title;
+    return `Request failed (${e.response.status}).`;
+  }
+  return e instanceof Error ? e.message : fallback;
+}

--- a/apps/web/src/pages/Login.tsx
+++ b/apps/web/src/pages/Login.tsx
@@ -1,6 +1,8 @@
 import { useState } from "react";
+import axios from "axios";
 import { useNavigate } from "react-router-dom";
 import { useAuth } from "../auth";
+import { apiErrorMessage } from "../lib/api";
 
 export default function Login() {
   const { login } = useAuth();
@@ -17,8 +19,14 @@ export default function Login() {
     try {
       await login(email, password);
       navigate("/");
-    } catch {
-      setError("Invalid email or password.");
+    } catch (err) {
+      // 401 from the API has no body and genuinely means bad credentials;
+      // anything else (500, network) shows the real reason.
+      setError(
+        axios.isAxiosError(err) && err.response?.status === 401
+          ? "Invalid email or password."
+          : apiErrorMessage(err, "Invalid email or password."),
+      );
     } finally {
       setBusy(false);
     }

--- a/src/Diariz.Api/Program.cs
+++ b/src/Diariz.Api/Program.cs
@@ -122,11 +122,26 @@ app.Run();
 
 static async Task SeedDefaultUserAsync(IServiceProvider sp, IConfiguration config)
 {
+    var logger = sp.GetRequiredService<ILoggerFactory>().CreateLogger("Seed");
     var email = config["Seed:Email"];
     var password = config["Seed:Password"];
-    if (string.IsNullOrWhiteSpace(email) || string.IsNullOrWhiteSpace(password)) return;
+    if (string.IsNullOrWhiteSpace(email) || string.IsNullOrWhiteSpace(password))
+    {
+        logger.LogWarning("Seed skipped: Seed:Email / Seed:Password not configured.");
+        return;
+    }
 
     var users = sp.GetRequiredService<UserManager<ApplicationUser>>();
-    if (await users.FindByEmailAsync(email) is not null) return;
-    await users.CreateAsync(new ApplicationUser { UserName = email, Email = email }, password);
+    if (await users.FindByEmailAsync(email) is not null)
+    {
+        logger.LogInformation("Seed user {Email} already exists; nothing to do.", email);
+        return;
+    }
+
+    var result = await users.CreateAsync(new ApplicationUser { UserName = email, Email = email }, password);
+    if (result.Succeeded)
+        logger.LogInformation("Seed user {Email} created.", email);
+    else
+        logger.LogError("Seed user {Email} creation FAILED: {Errors}", email,
+            string.Join("; ", result.Errors.Select(e => e.Description)));
 }


### PR DESCRIPTION
Two diagnosability improvements prompted by the Milestone 1 deploy session — where a silently-failing seed and generic UI messages turned small problems into long debugging loops.

## API — log the seed outcome
`SeedDefaultUserAsync` previously called `UserManager.CreateAsync` and ignored the result, so a failed or skipped seed was invisible (this is why the login user never got created until it was registered manually). It now logs one of:
- `Seed skipped: Seed:Email / Seed:Password not configured.` (warning)
- `Seed user {Email} already exists; nothing to do.`
- `Seed user {Email} created.`
- `Seed user {Email} creation FAILED: {Errors}` (error, with Identity descriptions)

## Web — surface the real error
Adds `apiErrorMessage()` in `lib/api.ts` that pulls a human-readable message out of an axios error across the shapes the API returns — plain strings (`BadRequest("...")`), Identity error arrays, ASP.NET `ProblemDetails` (`{ title, errors }`), and "no response" (network). 

- **Login**: keeps the friendly `"Invalid email or password."` for a 401 (that response has no body), but shows the real message/status for anything else (500, network).
- **Recorder**: replaces the blanket `"Upload failed."` with the actual server reason; the generic string remains only as a last-resort fallback.

## Verification
- `dotnet build` — 0 warnings / 0 errors.
- `tsc` + `vite build` — clean.

No behavioural/runtime change to the pipeline itself; purely better error reporting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)