### PR TITLE
Add .NET test harness (unit + integration) and adopt TDD

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,175 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+Diariz is a multi-user voice/meeting transcription platform: record audio → upload → transcribe
+server-side with **speaker diarization** + word-level timestamps → view speaker-labeled segments.
+Currently at **Milestone 1** (capture → transcribe → view). LLM summaries (M2), RAG chat over
+embeddings (M3), and packaging/TLS (M4) are scaffolded but not built — see `docs/Overall_Synopsis_of_Platform.md`
+and the roadmap in `README.md`.
+
+## Architecture & data flow
+
+Four deployables that communicate across process/language boundaries:
+
+| Component | Stack | Path |
+|---|---|---|
+| API / auth / orchestration | ASP.NET Core (**.NET 10**) + EF Core + SignalR | `src/Diariz.Api` |
+| Domain model + migrations | EF Core + Postgres/pgvector | `src/Diariz.Domain` |
+| Transcription worker | Python: WhisperX (large-v3) + pyannote 3.1, GPU | `src/Diariz.Worker` |
+| Web UI | React 19 + TS + Vite + Tailwind v4 | `apps/web` |
+| Desktop shell | Electron (mic + Windows loopback capture) | `apps/desktop` |
+
+**End-to-end flow:** client records → `POST /api/recordings` (multipart) → API stores the blob in
+MinIO and a `Recording` row in Postgres → API creates a `Transcription` row (versioned) and
+**enqueues a job on a Redis Stream** → Python worker `XREADGROUP`s the job, downloads the blob,
+runs WhisperX→align→pyannote, and **POSTs segments back** to `internal/transcriptions/result` →
+API persists `Segment`s + seeds `Speaker` rows → notifies the browser over **SignalR**
+(`RecordingStatusChanged`) → the detail page refetches.
+
+### Cross-boundary contracts (the non-obvious glue)
+
+- **Redis Stream job queue.** Stream key `transcription-jobs`, consumer group `workers` (see
+  `worker/config.py` and `Api/Services/JobQueue.cs`). The job payload is JSON with **PascalCase**
+  keys (`TranscriptionId`, `BlobKey`, `Model`) — produced by .NET, consumed by Python. The worker's
+  callback bodies are also PascalCase so .NET model binding works. Keep both sides in sync when
+  changing `TranscriptionJob` / `TranscriptionResult` / `Segment` shapes.
+- **Worker → API callback** uses route `internal/transcriptions/*` and is authenticated by a shared
+  secret header `X-Worker-Secret` (= `CALLBACK_SECRET`), **not** JWT. It is not user-facing.
+- **SignalR auth.** The hub (`/hubs/transcription`) requires JWT; browsers can't set Authorization
+  headers on the WS handshake, so the token is passed as the `access_token` query string and picked
+  up in `Program.cs` `OnMessageReceived`. Clients are auto-joined to a per-user group (group name =
+  user GUID) so status events are scoped per user.
+
+### Domain model notes
+
+- **Transcriptions are versioned per recording** (`(RecordingId, Version)` unique). `Retranscribe`
+  bumps the version; `GET /api/recordings/{id}` returns only the highest-version transcription.
+- **Speaker renames are preserved across re-transcribes.** Worker emits diarization labels
+  (`SPEAKER_00`...); the callback seeds a `Speaker` row per new label with `DisplayName = label`,
+  and the UI's rename updates `DisplayName` only.
+- **pgvector** column is `vector(768)` on `Segment.Embedding` (sized for `nomic-embed-text`).
+  Embeddings/RAG are unused in M1 — adjust the dimension via a migration if the embed model changes.
+  `OnModelCreating` applies the pgvector extension + column **only when the provider is Npgsql**
+  (`Database.IsNpgsql()`); under other providers (the in-memory test provider) the property is
+  `Ignore`d. Keep new Postgres-only model config behind that same guard so unit tests can build the model.
+- All user-scoped queries filter by `UserId` from the JWT `NameIdentifier` claim — preserve this
+  ownership check on every recording endpoint.
+
+## Test-driven development (required)
+
+**This project uses TDD. Write the failing test first, watch it fail, then write the minimal code
+to pass.** No production code without a failing test that preceded it. This applies to new features,
+bug fixes, and behavior changes. When fixing a bug, first add a test that reproduces it (red), then
+fix (green). Exceptions (throwaway spikes, generated code, pure config) need a human's sign-off.
+
+Keep test output pristine — a passing run has no errors or warnings.
+
+## Commands
+
+### Backend (.NET API + Domain)
+`Diariz.slnx` contains **only** the Api and Domain projects (the worker is Python, web/desktop are npm).
+
+```bash
+dotnet build Diariz.slnx
+dotnet run --project src/Diariz.Api          # needs Postgres/Redis/MinIO reachable
+```
+
+### Tests (.NET)
+Three test projects, all in `Diariz.slnx`:
+
+| Project | Kind | Docker? |
+|---|---|---|
+| `tests/Diariz.Api.Tests` | Fast unit tests (xUnit) | No |
+| `tests/Diariz.Api.IntegrationTests` | Integration tests (Testcontainers) | **Yes** |
+| `tests/Diariz.Api.TestSupport` | Shared fakes/helpers (not a test project) | — |
+
+```bash
+dotnet test                                              # everything (needs Docker for integration)
+dotnet test tests/Diariz.Api.Tests                       # fast unit tests only, no Docker
+dotnet test tests/Diariz.Api.IntegrationTests            # integration only (needs Docker)
+dotnet test --filter "FullyQualifiedName~WorkerCallback" # one class / name substring
+dotnet test --filter "Name=Result_WithWrongSecret_ReturnsUnauthorized"  # one test
+```
+
+**Unit tests (`Diariz.Api.Tests`) — no Docker.** They use the **EF Core in-memory provider**
+(`TestDb.Create()` gives each test an isolated database) and hand-rolled fakes for the external
+boundaries. The fakes/helpers live in **`Diariz.Api.TestSupport`** (namespace
+`Diariz.Api.Tests.Infrastructure`, shared with the integration project): `FakeJobQueue` (Redis),
+`FakeAudioStorage` (MinIO/S3), `FakeHubContext` (SignalR — records the messages a controller pushed),
+and `Http.Context(userId, headers)` (builds a `ControllerContext` with an authenticated user /
+headers). **No mocking library** — add a fake to `TestSupport` rather than reaching for one.
+
+**Integration tests (`Diariz.Api.IntegrationTests`) — needs Docker.** `ContainersFixture` (an
+`ICollectionFixture`) spins up real **Postgres/pgvector, Redis, and MinIO** via Testcontainers once
+per run, applies EF migrations, and exposes connection strings + `CreateDbContext()`. All classes
+share the `"integration"` collection so they run sequentially against one set of containers; tests
+isolate via unique ids/keys rather than per-test databases. Use this layer for anything that depends
+on real relational/query behavior, FK enforcement, the pgvector column, the Redis stream wire format,
+or S3/MinIO round-trips.
+
+**In-memory provider caveat:** it does not faithfully translate relational queries (e.g. it **ignores
+ordering/`Take` inside a filtered `Include`**, and does not enforce FKs). Behavior like the "current =
+highest-version transcription" rule in `RecordingsController.Get` is therefore `[Fact(Skip=...)]` in
+the unit project and verified for real in the integration project instead. Don't "fix" a skipped unit
+test by gaming the in-memory provider — move it to the integration harness.
+
+The API **auto-runs EF migrations, seeds the default user, and ensures the MinIO bucket on startup**
+(`Program.cs`) — you do not run `database update` manually for normal dev.
+
+EF migrations (the `DbContext` lives in `Diariz.Domain`, but it's an ASP.NET host, so use the startup project):
+```bash
+dotnet ef migrations add <Name> --project src/Diariz.Domain --startup-project src/Diariz.Api
+```
+`DiarizDbContextFactory` exists for design-time tooling.
+
+### Worker (Python)
+```bash
+cd src/Diariz.Worker
+pip install torch torchaudio --index-url https://download.pytorch.org/whl/cu121
+pip install -r requirements.txt
+HF_TOKEN=... REDIS_URL=redis://localhost:6379/0 API_BASE_URL=http://localhost:8080 python worker.py
+```
+Diarization is gated: you **must** set `HF_TOKEN` and accept the `pyannote/speaker-diarization-3.1`
++ `pyannote/segmentation-3.0` terms on Hugging Face, or jobs fail. CPU-only: `DEVICE=cpu COMPUTE_TYPE=int8` (slow).
+
+### Web
+```bash
+cd apps/web
+npm run dev        # http://localhost:5173, proxies /api and /hubs to :8080
+npm run build      # tsc typecheck + vite build
+```
+
+### Desktop (Electron)
+```bash
+cd apps/desktop && npm run dev    # sets DIARIZ_DEV=1, loads the Vite dev server
+```
+Only the Electron shell can capture **system/loopback** audio (`setDisplayMediaRequestHandler` →
+`audio: "loopback"`, Windows only). It exposes `window.diariz.isElectron` to enable the "System
+audio" recorder option, and can override the API base via `window.__DIARIZ_API_BASE__`.
+
+### Full stack (Docker)
+```bash
+cd deploy
+cp .env.example .env      # JWT_KEY, CALLBACK_SECRET, HF_TOKEN, SEED_EMAIL/PASSWORD, MinIO creds
+docker compose up --build # postgres, redis, minio, api, GPU worker
+```
+The GPU worker needs the NVIDIA Container Toolkit; for CPU comment out the `deploy.resources` GPU
+block and set `WORKER_DEVICE=cpu WORKER_COMPUTE_TYPE=int8`.
+
+## Conventions & gotchas
+
+- **Tests:** the .NET harness exists (`tests/Diariz.Api.Tests`, see above). The Python worker and
+  web app do **not** have test harnesses yet — add `pytest` / `vitest` when working in those.
+- **Ports:** API `8080`; web `5173`; Postgres `5432`; Redis `6379`; **MinIO is remapped on the host**
+  — S3 API `9002→9000`, console `9003→9001` (avoids clashing with other local MinIO instances).
+  In-container, services use the compose service names (`minio:9000`, `redis:6379`, `postgres:5432`).
+- **MinIO/S3 quirk:** `AmazonS3Config` uses `ForcePathStyle` + region `us-east-1`. A prior bug
+  required removing `DisablePayloadSigning` on `PutObject` for MinIO uploads to work — be cautious
+  changing S3 request options in `Services/AudioStorage.cs`.
+- Config binds via the options pattern (`Configuration/AppOptions.cs`): `Jwt`, `Storage`,
+  `JobQueue`, `Worker` sections, settable through `__`-delimited env vars in compose.
+- Worker model load is **lazy + cached** in `pipeline.py` (Whisper/align/diarizer load once and are
+  reused across jobs — loading large-v3 + pyannote is expensive).

--- a/Diariz.slnx
+++ b/Diariz.slnx
@@ -3,4 +3,9 @@
     <Project Path="src/Diariz.Api/Diariz.Api.csproj" />
     <Project Path="src/Diariz.Domain/Diariz.Domain.csproj" />
   </Folder>
+  <Folder Name="/tests/">
+    <Project Path="tests/Diariz.Api.IntegrationTests/Diariz.Api.IntegrationTests.csproj" />
+    <Project Path="tests/Diariz.Api.Tests/Diariz.Api.Tests.csproj" />
+    <Project Path="tests/Diariz.Api.TestSupport/Diariz.Api.TestSupport.csproj" />
+  </Folder>
 </Solution>

--- a/src/Diariz.Domain/DiarizDbContext.cs
+++ b/src/Diariz.Domain/DiarizDbContext.cs
@@ -18,9 +18,15 @@ public class DiarizDbContext(DbContextOptions<DiarizDbContext> options)
     {
         base.OnModelCreating(builder);
 
+        // The vector column and pgvector extension only exist on Postgres. Under other
+        // providers (e.g. the EF in-memory provider used by unit tests) the embedding is
+        // unmapped — it is unused before Milestone 3 anyway.
+        var isNpgsql = Database.IsNpgsql();
+
         // pgvector extension; embedding dimension is for typical local embedding models
         // (e.g. nomic-embed-text = 768). Adjust the migration if a different model is chosen.
-        builder.HasPostgresExtension("vector");
+        if (isNpgsql)
+            builder.HasPostgresExtension("vector");
 
         builder.Entity<Recording>(e =>
         {
@@ -52,7 +58,10 @@ public class DiarizDbContext(DbContextOptions<DiarizDbContext> options)
         builder.Entity<Segment>(e =>
         {
             e.HasIndex(s => new { s.TranscriptionId, s.Ordinal });
-            e.Property(s => s.Embedding).HasColumnType("vector(768)");
+            if (isNpgsql)
+                e.Property(s => s.Embedding).HasColumnType("vector(768)");
+            else
+                e.Ignore(s => s.Embedding);
         });
 
         builder.Entity<Speaker>(e =>

--- a/tests/Diariz.Api.IntegrationTests/AudioStorageIntegrationTests.cs
+++ b/tests/Diariz.Api.IntegrationTests/AudioStorageIntegrationTests.cs
@@ -1,0 +1,73 @@
+using System.Text;
+using Amazon.Runtime;
+using Amazon.S3;
+using Diariz.Api.Configuration;
+using Diariz.Api.IntegrationTests.Infrastructure;
+using Diariz.Api.Services;
+using Microsoft.Extensions.Options;
+
+namespace Diariz.Api.IntegrationTests;
+
+[Collection(IntegrationCollection.Name)]
+public class AudioStorageIntegrationTests(ContainersFixture fx)
+{
+    // Mirrors the S3 client wiring in Program.cs (path-style, us-east-1) against the MinIO container.
+    private AudioStorage CreateStorage(out StorageOptions opts)
+    {
+        opts = new StorageOptions
+        {
+            Endpoint = fx.MinioEndpoint,
+            AccessKey = fx.MinioAccessKey,
+            SecretKey = fx.MinioSecretKey,
+            Bucket = $"recordings-{Guid.NewGuid():N}",
+            ForcePathStyle = true
+        };
+        var cfg = new AmazonS3Config
+        {
+            ServiceURL = opts.Endpoint,
+            ForcePathStyle = true,
+            AuthenticationRegion = "us-east-1"
+        };
+        var s3 = new AmazonS3Client(new BasicAWSCredentials(opts.AccessKey, opts.SecretKey), cfg);
+        return new AudioStorage(s3, Options.Create(opts));
+    }
+
+    [Fact]
+    public async Task EnsureBucket_ThenUpload_ThenOpenRead_RoundTripsBytes()
+    {
+        var storage = CreateStorage(out _);
+        await storage.EnsureBucketAsync();
+
+        var key = $"{Guid.NewGuid()}/audio.webm";
+        var payload = Encoding.UTF8.GetBytes("pretend this is webm audio");
+
+        using (var input = new MemoryStream(payload))
+            await storage.UploadAsync(key, input, "audio/webm");
+
+        await using var read = await storage.OpenReadAsync(key);
+        using var output = new MemoryStream();
+        await read.CopyToAsync(output);
+
+        Assert.Equal(payload, output.ToArray());
+    }
+
+    [Fact]
+    public async Task EnsureBucket_IsIdempotent()
+    {
+        var storage = CreateStorage(out _);
+        await storage.EnsureBucketAsync();
+        await storage.EnsureBucketAsync(); // must not throw when the bucket already exists
+    }
+
+    [Fact]
+    public async Task GetPresignedDownloadUrl_TargetsBucketAndKey()
+    {
+        var storage = CreateStorage(out var opts);
+        await storage.EnsureBucketAsync();
+
+        var url = storage.GetPresignedDownloadUrl("some/object.webm", TimeSpan.FromMinutes(5));
+
+        Assert.Contains(opts.Bucket, url);          // path-style => bucket is in the URL path
+        Assert.Contains("some/object.webm", url);
+    }
+}

--- a/tests/Diariz.Api.IntegrationTests/DatabaseIntegrationTests.cs
+++ b/tests/Diariz.Api.IntegrationTests/DatabaseIntegrationTests.cs
@@ -1,0 +1,97 @@
+using Diariz.Api.Contracts;
+using Diariz.Api.Controllers;
+using Diariz.Api.IntegrationTests.Infrastructure;
+using Diariz.Api.Tests.Infrastructure;
+using Diariz.Domain.Entities;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Pgvector;
+
+namespace Diariz.Api.IntegrationTests;
+
+[Collection(IntegrationCollection.Name)]
+public class DatabaseIntegrationTests(ContainersFixture fx)
+{
+    private async Task<ApplicationUser> SeedUser()
+    {
+        await using var db = fx.CreateDbContext();
+        var user = new ApplicationUser { Id = Guid.NewGuid(), UserName = $"{Guid.NewGuid()}@x.test", Email = "u@x.test" };
+        db.Users.Add(user);
+        await db.SaveChangesAsync();
+        return user;
+    }
+
+    [Fact]
+    public async Task Migrations_Apply_AndVectorColumnRoundTrips()
+    {
+        var user = await SeedUser();
+        var segId = Guid.NewGuid();
+
+        await using (var db = fx.CreateDbContext())
+        {
+            var rec = new Recording { Id = Guid.NewGuid(), UserId = user.Id, BlobKey = "k" };
+            var tr = new Transcription { Id = Guid.NewGuid(), RecordingId = rec.Id, Model = "m", Version = 1 };
+            var seg = new Segment
+            {
+                Id = segId,
+                TranscriptionId = tr.Id,
+                SpeakerLabel = "SPEAKER_00",
+                Text = "hello",
+                Ordinal = 0,
+                Embedding = new Vector(Enumerable.Range(0, 768).Select(i => (float)i).ToArray())
+            };
+            db.AddRange(rec, tr, seg);
+            await db.SaveChangesAsync();
+        }
+
+        // Re-read on a fresh context to prove the vector(768) column persisted and maps back.
+        await using var db2 = fx.CreateDbContext();
+        var loaded = await db2.Segments.SingleAsync(s => s.Id == segId);
+        Assert.NotNull(loaded.Embedding);
+        Assert.Equal(768, loaded.Embedding!.ToArray().Length);
+        Assert.Equal(5f, loaded.Embedding.ToArray()[5]);
+    }
+
+    [Fact]
+    public async Task ForeignKey_RejectsRecordingWithUnknownUser()
+    {
+        await using var db = fx.CreateDbContext();
+        db.Recordings.Add(new Recording { Id = Guid.NewGuid(), UserId = Guid.NewGuid(), BlobKey = "k" });
+
+        // Real Postgres enforces the FK to AspNetUsers — the in-memory provider does not.
+        await Assert.ThrowsAnyAsync<DbUpdateException>(() => db.SaveChangesAsync());
+    }
+
+    [Fact]
+    public async Task Get_ReturnsOnlyHighestVersionTranscription()
+    {
+        var user = await SeedUser();
+        var recId = Guid.NewGuid();
+
+        await using (var seed = fx.CreateDbContext())
+        {
+            seed.Recordings.Add(new Recording { Id = recId, UserId = user.Id, BlobKey = "k" });
+            foreach (var v in new[] { 1, 2, 3 })
+                seed.Transcriptions.Add(new Transcription { Id = Guid.NewGuid(), RecordingId = recId, Model = "m", Version = v });
+            await seed.SaveChangesAsync();
+        }
+
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?> { ["Transcription:DefaultModel"] = "whisperx-large-v3" })
+            .Build();
+
+        await using var db = fx.CreateDbContext();
+        var controller = new RecordingsController(db, new FakeAudioStorage(), new FakeJobQueue(), new FakeHubContext(), config)
+        {
+            ControllerContext = Http.Context(user.Id)
+        };
+
+        var result = await controller.Get(recId);
+
+        // The filtered Include (OrderByDescending(Version).Take(1)) is translated by Postgres here,
+        // unlike the in-memory provider where this assertion cannot hold.
+        var dto = Assert.IsType<RecordingDetailDto>(result.Value);
+        Assert.Equal(3, dto.Current!.Version);
+    }
+}

--- a/tests/Diariz.Api.IntegrationTests/Diariz.Api.IntegrationTests.csproj
+++ b/tests/Diariz.Api.IntegrationTests/Diariz.Api.IntegrationTests.csproj
@@ -1,0 +1,33 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <!-- Real Postgres/pgvector, Redis, and MinIO spun up in Docker per test run. -->
+    <PackageReference Include="Testcontainers.PostgreSql" Version="4.*" />
+    <PackageReference Include="Testcontainers.Redis" Version="4.*" />
+    <PackageReference Include="Testcontainers.Minio" Version="4.*" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Diariz.Api\Diariz.Api.csproj" />
+    <ProjectReference Include="..\Diariz.Api.TestSupport\Diariz.Api.TestSupport.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Diariz.Api.IntegrationTests/GlobalUsings.cs
+++ b/tests/Diariz.Api.IntegrationTests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/tests/Diariz.Api.IntegrationTests/Infrastructure/ContainersFixture.cs
+++ b/tests/Diariz.Api.IntegrationTests/Infrastructure/ContainersFixture.cs
@@ -1,0 +1,59 @@
+using Diariz.Domain;
+using Microsoft.EntityFrameworkCore;
+using Testcontainers.Minio;
+using Testcontainers.PostgreSql;
+using Testcontainers.Redis;
+
+namespace Diariz.Api.IntegrationTests.Infrastructure;
+
+/// <summary>
+/// Starts real Postgres (with pgvector), Redis, and MinIO once for the whole test assembly and
+/// applies EF migrations against the database. Containers are torn down when the assembly finishes.
+/// Tests share these containers (they run sequentially via the collection) and isolate themselves
+/// with unique ids / keys rather than per-test databases.
+/// </summary>
+public sealed class ContainersFixture : IAsyncLifetime
+{
+    // Same images as deploy/docker-compose.yml. The image is passed to the builder constructor
+    // (the parameterless ctor + WithImage is obsolete in Testcontainers 4.x).
+    private readonly PostgreSqlContainer _postgres = new PostgreSqlBuilder("pgvector/pgvector:pg16").Build();
+    private readonly RedisContainer _redis = new RedisBuilder("redis:7-alpine").Build();
+    private readonly MinioContainer _minio = new MinioBuilder("minio/minio:latest").Build();
+
+    public string PostgresConnectionString => _postgres.GetConnectionString();
+    public string RedisConnectionString => _redis.GetConnectionString();
+    public string MinioEndpoint => _minio.GetConnectionString();
+    public string MinioAccessKey => _minio.GetAccessKey();
+    public string MinioSecretKey => _minio.GetSecretKey();
+
+    public DiarizDbContext CreateDbContext()
+    {
+        var options = new DbContextOptionsBuilder<DiarizDbContext>()
+            .UseNpgsql(PostgresConnectionString, o => o.UseVector())
+            .Options;
+        return new DiarizDbContext(options);
+    }
+
+    public async Task InitializeAsync()
+    {
+        await Task.WhenAll(_postgres.StartAsync(), _redis.StartAsync(), _minio.StartAsync());
+
+        // Exercise the real migration pipeline (CREATE EXTENSION vector, vector(768) column, indexes).
+        await using var db = CreateDbContext();
+        await db.Database.MigrateAsync();
+    }
+
+    public async Task DisposeAsync()
+    {
+        await _postgres.DisposeAsync();
+        await _redis.DisposeAsync();
+        await _minio.DisposeAsync();
+    }
+}
+
+/// <summary>All integration tests share one fixture, so they run sequentially against one set of containers.</summary>
+[CollectionDefinition(Name)]
+public sealed class IntegrationCollection : ICollectionFixture<ContainersFixture>
+{
+    public const string Name = "integration";
+}

--- a/tests/Diariz.Api.IntegrationTests/RedisJobQueueIntegrationTests.cs
+++ b/tests/Diariz.Api.IntegrationTests/RedisJobQueueIntegrationTests.cs
@@ -1,0 +1,39 @@
+using System.Text.Json;
+using Diariz.Api.Configuration;
+using Diariz.Api.Contracts;
+using Diariz.Api.IntegrationTests.Infrastructure;
+using Diariz.Api.Services;
+using Microsoft.Extensions.Options;
+using StackExchange.Redis;
+
+namespace Diariz.Api.IntegrationTests;
+
+[Collection(IntegrationCollection.Name)]
+public class RedisJobQueueIntegrationTests(ContainersFixture fx)
+{
+    [Fact]
+    public async Task EnqueueAsync_AddsJsonJobToTheStream()
+    {
+        using var mux = await ConnectionMultiplexer.ConnectAsync(fx.RedisConnectionString);
+        var opts = Options.Create(new JobQueueOptions { StreamKey = $"jobs-{Guid.NewGuid()}" });
+        var queue = new RedisJobQueue(mux, opts);
+
+        var job = new TranscriptionJob(Guid.NewGuid(), Guid.NewGuid(), "user/blob.webm", "whisperx-large-v3");
+        await queue.EnqueueAsync(job);
+
+        // The Python worker reads this exact shape: one stream entry with a PascalCase-JSON "job" field.
+        var entries = await mux.GetDatabase().StreamRangeAsync(opts.Value.StreamKey, "-", "+");
+        var entry = Assert.Single(entries);
+        var jobField = entry.Values.Single(v => v.Name == "job");
+        var json = jobField.Value.ToString();
+
+        var roundTripped = JsonSerializer.Deserialize<TranscriptionJob>(json);
+        Assert.Equal(job.TranscriptionId, roundTripped!.TranscriptionId);
+        Assert.Equal(job.RecordingId, roundTripped.RecordingId);
+        Assert.Equal("user/blob.webm", roundTripped.BlobKey);
+        Assert.Equal("whisperx-large-v3", roundTripped.Model);
+
+        // Guard the wire contract: keys must stay PascalCase or the worker breaks.
+        Assert.Contains("\"BlobKey\"", json);
+    }
+}

--- a/tests/Diariz.Api.TestSupport/Diariz.Api.TestSupport.csproj
+++ b/tests/Diariz.Api.TestSupport/Diariz.Api.TestSupport.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <!-- Shared test doubles touch ASP.NET Core types (controllers, SignalR). -->
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Diariz.Api\Diariz.Api.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Diariz.Api.TestSupport/Fakes.cs
+++ b/tests/Diariz.Api.TestSupport/Fakes.cs
@@ -1,0 +1,85 @@
+using Diariz.Api.Contracts;
+using Diariz.Api.Hubs;
+using Diariz.Api.Services;
+using Microsoft.AspNetCore.SignalR;
+
+namespace Diariz.Api.Tests.Infrastructure;
+
+/// <summary>Records the jobs that would have been pushed onto the Redis stream.</summary>
+public sealed class FakeJobQueue : IJobQueue
+{
+    public List<TranscriptionJob> Enqueued { get; } = new();
+
+    public Task EnqueueAsync(TranscriptionJob job, CancellationToken ct = default)
+    {
+        Enqueued.Add(job);
+        return Task.CompletedTask;
+    }
+}
+
+/// <summary>In-memory stand-in for MinIO/S3. Records uploads as byte arrays.</summary>
+public sealed class FakeAudioStorage : IAudioStorage
+{
+    public Dictionary<string, byte[]> Objects { get; } = new();
+    public string PresignedUrl { get; set; } = "https://example.test/audio";
+
+    public Task EnsureBucketAsync(CancellationToken ct = default) => Task.CompletedTask;
+
+    public async Task UploadAsync(string key, Stream content, string contentType, CancellationToken ct = default)
+    {
+        using var ms = new MemoryStream();
+        await content.CopyToAsync(ms, ct);
+        Objects[key] = ms.ToArray();
+    }
+
+    public Task<Stream> OpenReadAsync(string key, CancellationToken ct = default) =>
+        Task.FromResult<Stream>(new MemoryStream(Objects[key]));
+
+    public string GetPresignedDownloadUrl(string key, TimeSpan expiry) => PresignedUrl;
+}
+
+/// <summary>
+/// No-op <see cref="IHubContext{THub}"/> that records every message sent so tests can assert
+/// which SignalR notifications a controller pushed, without a real hub connection.
+/// </summary>
+public sealed class FakeHubContext : IHubContext<TranscriptionHub>
+{
+    private readonly FakeHubClients _clients = new();
+    public List<SentMessage> Sent => _clients.Sent;
+
+    public IHubClients Clients => _clients;
+    public IGroupManager Groups { get; } = new FakeGroupManager();
+
+    public sealed record SentMessage(string? Group, string Method, object?[] Args);
+
+    private sealed class FakeHubClients : IHubClients
+    {
+        public List<SentMessage> Sent { get; } = new();
+        private IClientProxy Proxy(string? group) => new FakeClientProxy(group, Sent);
+
+        public IClientProxy All => Proxy(null);
+        public IClientProxy AllExcept(IReadOnlyList<string> excluded) => Proxy(null);
+        public IClientProxy Client(string connectionId) => Proxy(null);
+        public IClientProxy Clients(IReadOnlyList<string> connectionIds) => Proxy(null);
+        public IClientProxy Group(string groupName) => Proxy(groupName);
+        public IClientProxy GroupExcept(string groupName, IReadOnlyList<string> excluded) => Proxy(groupName);
+        public IClientProxy Groups(IReadOnlyList<string> groupNames) => Proxy(null);
+        public IClientProxy User(string userId) => Proxy(null);
+        public IClientProxy Users(IReadOnlyList<string> userIds) => Proxy(null);
+    }
+
+    private sealed class FakeClientProxy(string? group, List<SentMessage> sink) : IClientProxy
+    {
+        public Task SendCoreAsync(string method, object?[] args, CancellationToken ct = default)
+        {
+            sink.Add(new SentMessage(group, method, args));
+            return Task.CompletedTask;
+        }
+    }
+
+    private sealed class FakeGroupManager : IGroupManager
+    {
+        public Task AddToGroupAsync(string connectionId, string groupName, CancellationToken ct = default) => Task.CompletedTask;
+        public Task RemoveFromGroupAsync(string connectionId, string groupName, CancellationToken ct = default) => Task.CompletedTask;
+    }
+}

--- a/tests/Diariz.Api.TestSupport/Http.cs
+++ b/tests/Diariz.Api.TestSupport/Http.cs
@@ -1,0 +1,20 @@
+using System.Security.Claims;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Diariz.Api.Tests.Infrastructure;
+
+/// <summary>Builds a <see cref="ControllerContext"/> with an optional authenticated user and headers.</summary>
+public static class Http
+{
+    public static ControllerContext Context(Guid? userId = null, params (string Key, string Value)[] headers)
+    {
+        var ctx = new DefaultHttpContext();
+        if (userId is { } id)
+            ctx.User = new ClaimsPrincipal(new ClaimsIdentity(
+                [new Claim(ClaimTypes.NameIdentifier, id.ToString())], authenticationType: "test"));
+        foreach (var (key, value) in headers)
+            ctx.Request.Headers[key] = value;
+        return new ControllerContext { HttpContext = ctx };
+    }
+}

--- a/tests/Diariz.Api.Tests/Diariz.Api.Tests.csproj
+++ b/tests/Diariz.Api.Tests/Diariz.Api.Tests.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <!-- In-memory EF provider for fast, Docker-free DB tests. -->
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="9.*" />
+  </ItemGroup>
+
+  <!-- The API is an ASP.NET Core app; tests touch controllers/SignalR types directly. -->
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Diariz.Api\Diariz.Api.csproj" />
+    <ProjectReference Include="..\Diariz.Api.TestSupport\Diariz.Api.TestSupport.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/tests/Diariz.Api.Tests/GlobalUsings.cs
+++ b/tests/Diariz.Api.Tests/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using Xunit;

--- a/tests/Diariz.Api.Tests/Infrastructure/TestDb.cs
+++ b/tests/Diariz.Api.Tests/Infrastructure/TestDb.cs
@@ -1,0 +1,22 @@
+using Diariz.Domain;
+using Microsoft.EntityFrameworkCore;
+
+namespace Diariz.Api.Tests.Infrastructure;
+
+/// <summary>
+/// Creates a fresh, isolated <see cref="DiarizDbContext"/> backed by the EF Core in-memory
+/// provider. Each call gets a unique database name so tests never share state. The in-memory
+/// provider ignores Postgres-specific config (pgvector column types, unique indexes), which is
+/// fine for testing query/orchestration logic — use the integration harness for constraint fidelity.
+/// </summary>
+public static class TestDb
+{
+    public static DiarizDbContext Create()
+    {
+        var name = $"diariz-tests-{Guid.NewGuid()}";
+        var options = new DbContextOptionsBuilder<DiarizDbContext>()
+            .UseInMemoryDatabase(name)
+            .Options;
+        return new DiarizDbContext(options);
+    }
+}

--- a/tests/Diariz.Api.Tests/RecordingsControllerTests.cs
+++ b/tests/Diariz.Api.Tests/RecordingsControllerTests.cs
@@ -1,0 +1,111 @@
+using Diariz.Api.Controllers;
+using Diariz.Api.Tests.Infrastructure;
+using Diariz.Domain;
+using Diariz.Domain.Entities;
+using Diariz.Api.Contracts;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+
+namespace Diariz.Api.Tests;
+
+public class RecordingsControllerTests
+{
+    private static RecordingsController Build(DiarizDbContext db, Guid userId, FakeJobQueue queue, FakeAudioStorage? storage = null)
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?> { ["Transcription:DefaultModel"] = "whisperx-large-v3" })
+            .Build();
+        return new RecordingsController(db, storage ?? new FakeAudioStorage(), queue, new FakeHubContext(), config)
+        {
+            ControllerContext = Http.Context(userId)
+        };
+    }
+
+    private static async Task<Recording> SeedRecording(DiarizDbContext db, Guid userId, params int[] versions)
+    {
+        var rec = new Recording
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            BlobKey = $"{userId}/blob.webm",
+            Status = RecordingStatus.Transcribed
+        };
+        db.Recordings.Add(rec);
+        foreach (var v in versions)
+            db.Transcriptions.Add(new Transcription { Id = Guid.NewGuid(), RecordingId = rec.Id, Model = "m", Version = v });
+        await db.SaveChangesAsync();
+        return rec;
+    }
+
+    [Fact]
+    public async Task Retranscribe_CreatesNextVersion_AndEnqueuesJob()
+    {
+        using var db = TestDb.Create();
+        var userId = Guid.NewGuid();
+        var queue = new FakeJobQueue();
+        var rec = await SeedRecording(db, userId, versions: 1);
+        var controller = Build(db, userId, queue);
+
+        var result = await controller.Retranscribe(rec.Id, new RetranscribeRequest(Model: null));
+
+        Assert.IsType<AcceptedResult>(result);
+
+        var versions = await db.Transcriptions.Where(t => t.RecordingId == rec.Id)
+            .Select(t => t.Version).OrderBy(v => v).ToListAsync();
+        Assert.Equal([1, 2], versions);
+
+        var job = Assert.Single(queue.Enqueued);
+        Assert.Equal(rec.Id, job.RecordingId);
+        Assert.Equal(rec.BlobKey, job.BlobKey);
+
+        var reloaded = await db.Recordings.FindAsync(rec.Id);
+        Assert.Equal(RecordingStatus.Queued, reloaded!.Status);
+    }
+
+    [Fact]
+    public async Task Retranscribe_UsesRequestedModel_WhenProvided()
+    {
+        using var db = TestDb.Create();
+        var userId = Guid.NewGuid();
+        var queue = new FakeJobQueue();
+        var rec = await SeedRecording(db, userId, versions: 1);
+        var controller = Build(db, userId, queue);
+
+        await controller.Retranscribe(rec.Id, new RetranscribeRequest(Model: "whisperx-medium"));
+
+        Assert.Equal("whisperx-medium", Assert.Single(queue.Enqueued).Model);
+    }
+
+    [Fact]
+    public async Task Get_ReturnsNotFound_ForRecordingOwnedByAnotherUser()
+    {
+        using var db = TestDb.Create();
+        var owner = Guid.NewGuid();
+        var rec = await SeedRecording(db, owner, versions: 1);
+        var controller = Build(db, userId: Guid.NewGuid(), new FakeJobQueue()); // different user
+
+        var result = await controller.Get(rec.Id);
+
+        Assert.IsType<NotFoundResult>(result.Result);
+    }
+
+    // The "current transcription = highest version" rule depends on a filtered Include
+    // (OrderByDescending(Version).Take(1)) that the database translates. The EF in-memory
+    // provider does NOT honour the ordering/Take inside a filtered Include (it loads the whole
+    // collection), so this behaviour can only be verified faithfully against real Postgres.
+    // Belongs in the integration (Testcontainers) harness — see CLAUDE.md.
+    [Fact(Skip = "Filtered-Include ordering is not emulated by the EF in-memory provider; covered by the integration harness.")]
+    public async Task Get_ReturnsOnlyHighestVersionTranscription()
+    {
+        using var db = TestDb.Create();
+        var userId = Guid.NewGuid();
+        var rec = await SeedRecording(db, userId, versions: [1, 2, 3]);
+        var controller = Build(db, userId, new FakeJobQueue());
+
+        var result = await controller.Get(rec.Id);
+
+        var dto = Assert.IsType<RecordingDetailDto>(result.Value);
+        Assert.Equal(3, dto.Current!.Version);
+    }
+}

--- a/tests/Diariz.Api.Tests/TokenServiceTests.cs
+++ b/tests/Diariz.Api.Tests/TokenServiceTests.cs
@@ -1,0 +1,44 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using Diariz.Api.Configuration;
+using Diariz.Api.Services;
+using Diariz.Domain.Entities;
+using Microsoft.Extensions.Options;
+
+namespace Diariz.Api.Tests;
+
+public class TokenServiceTests
+{
+    private static TokenService Create(JwtOptions? opts = null) =>
+        new(Options.Create(opts ?? new JwtOptions
+        {
+            Issuer = "diariz",
+            Audience = "diariz",
+            Key = "test-signing-key-at-least-32-bytes-long!!",
+            AccessTokenMinutes = 60
+        }));
+
+    [Fact]
+    public void CreateAccessToken_PutsUserIdInNameIdentifierClaim()
+    {
+        var user = new ApplicationUser { Id = Guid.NewGuid(), Email = "a@b.test" };
+
+        var (token, _) = Create().CreateAccessToken(user);
+
+        var jwt = new JwtSecurityTokenHandler().ReadJwtToken(token);
+        var nameId = jwt.Claims.First(c => c.Type == ClaimTypes.NameIdentifier).Value;
+        Assert.Equal(user.Id.ToString(), nameId);
+    }
+
+    [Fact]
+    public void CreateAccessToken_ExpiryHonoursConfiguredMinutes()
+    {
+        var before = DateTimeOffset.UtcNow;
+
+        var (_, expiresAt) = Create(new JwtOptions { Key = new string('k', 40), AccessTokenMinutes = 60 })
+            .CreateAccessToken(new ApplicationUser { Id = Guid.NewGuid() });
+
+        // ~60 minutes out, allowing a little slack for execution time.
+        Assert.InRange(expiresAt, before.AddMinutes(59), before.AddMinutes(61));
+    }
+}

--- a/tests/Diariz.Api.Tests/WorkerCallbackControllerTests.cs
+++ b/tests/Diariz.Api.Tests/WorkerCallbackControllerTests.cs
@@ -1,0 +1,114 @@
+using Diariz.Api.Configuration;
+using Diariz.Api.Contracts;
+using Diariz.Api.Controllers;
+using Diariz.Api.Tests.Infrastructure;
+using Diariz.Domain;
+using Diariz.Domain.Entities;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+
+namespace Diariz.Api.Tests;
+
+public class WorkerCallbackControllerTests
+{
+    private const string Secret = "shared-secret";
+
+    private static (WorkerCallbackController controller, DiarizDbContext db, FakeHubContext hub) Build(string presentedSecret)
+    {
+        var db = TestDb.Create();
+        var hub = new FakeHubContext();
+        var controller = new WorkerCallbackController(db, hub, Options.Create(new WorkerOptions { CallbackSecret = Secret }))
+        {
+            ControllerContext = Http.Context(headers: ("X-Worker-Secret", presentedSecret))
+        };
+        return (controller, db, hub);
+    }
+
+    private static async Task<(Guid recordingId, Guid transcriptionId)> SeedQueuedRecording(DiarizDbContext db, Guid userId)
+    {
+        var rec = new Recording { Id = Guid.NewGuid(), UserId = userId, Status = RecordingStatus.Queued };
+        var tr = new Transcription { Id = Guid.NewGuid(), RecordingId = rec.Id, Model = "whisperx-large-v3", Version = 1 };
+        db.Recordings.Add(rec);
+        db.Transcriptions.Add(tr);
+        await db.SaveChangesAsync();
+        return (rec.Id, tr.Id);
+    }
+
+    [Fact]
+    public async Task Result_WithWrongSecret_ReturnsUnauthorized()
+    {
+        var (controller, db, _) = Build(presentedSecret: "not-the-secret");
+        var (_, transcriptionId) = await SeedQueuedRecording(db, Guid.NewGuid());
+
+        var result = await controller.Result(new TranscriptionResult(transcriptionId, "en", []));
+
+        Assert.IsType<UnauthorizedResult>(result);
+    }
+
+    [Fact]
+    public async Task Result_PersistsSegments_SeedsSpeakers_AndMarksTranscribed()
+    {
+        var (controller, db, hub) = Build(presentedSecret: Secret);
+        var userId = Guid.NewGuid();
+        var (recordingId, transcriptionId) = await SeedQueuedRecording(db, userId);
+
+        var body = new TranscriptionResult(transcriptionId, "en",
+        [
+            new SegmentResult("SPEAKER_00", 0, 1000, "Hello"),
+            new SegmentResult("SPEAKER_01", 1000, 2000, "Hi there"),
+            new SegmentResult("SPEAKER_00", 2000, 3000, "How are you"),
+        ]);
+
+        var result = await controller.Result(body);
+
+        Assert.IsType<OkResult>(result);
+
+        var segments = await db.Segments.Where(s => s.TranscriptionId == transcriptionId)
+            .OrderBy(s => s.Ordinal).ToListAsync();
+        Assert.Equal(3, segments.Count);
+        Assert.Equal([0, 1, 2], segments.Select(s => s.Ordinal));
+        Assert.Equal("Hello", segments[0].Text);
+
+        // One Speaker row per distinct label, default display name = label.
+        var speakers = await db.Speakers.Where(s => s.RecordingId == recordingId).ToListAsync();
+        Assert.Equal(2, speakers.Count);
+        Assert.All(speakers, s => Assert.Equal(s.Label, s.DisplayName));
+
+        var rec = await db.Recordings.FindAsync(recordingId);
+        Assert.Equal(RecordingStatus.Transcribed, rec!.Status);
+
+        // The owning user was notified over SignalR.
+        var msg = Assert.Single(hub.Sent);
+        Assert.Equal(userId.ToString(), msg.Group);
+        Assert.Equal("RecordingStatusChanged", msg.Method);
+    }
+
+    [Fact]
+    public async Task Result_BlankSpeakerLabel_StoredAsUnknown()
+    {
+        var (controller, db, _) = Build(presentedSecret: Secret);
+        var (_, transcriptionId) = await SeedQueuedRecording(db, Guid.NewGuid());
+
+        await controller.Result(new TranscriptionResult(transcriptionId, "en",
+            [new SegmentResult("", 0, 500, "mumble")]));
+
+        var seg = await db.Segments.SingleAsync(s => s.TranscriptionId == transcriptionId);
+        Assert.Equal("UNKNOWN", seg.SpeakerLabel);
+    }
+
+    [Fact]
+    public async Task Failure_RecordsErrorAndMarksFailed()
+    {
+        var (controller, db, hub) = Build(presentedSecret: Secret);
+        var (recordingId, transcriptionId) = await SeedQueuedRecording(db, Guid.NewGuid());
+
+        var result = await controller.Failure(new TranscriptionFailure(transcriptionId, "model exploded"));
+
+        Assert.IsType<OkResult>(result);
+        var rec = await db.Recordings.FindAsync(recordingId);
+        Assert.Equal(RecordingStatus.Failed, rec!.Status);
+        Assert.Equal("model exploded", rec.Error);
+        Assert.Single(hub.Sent);
+    }
+}


### PR DESCRIPTION
## Summary
- Adopt **test-driven development** as the project's working method (documented in CLAUDE.md).
- Add a fast **unit** harness (`tests/Diariz.Api.Tests`) using the EF Core in-memory provider plus hand-rolled fakes — no Docker, no mocking library.
- Add an **integration** harness (`tests/Diariz.Api.IntegrationTests`) using Testcontainers to spin up real Postgres/pgvector, Redis, and MinIO.
- Extract shared fakes/helpers into `tests/Diariz.Api.TestSupport`.
- Make the pgvector model config provider-aware so the in-memory provider can build the model (Postgres behavior unchanged).

## Coverage
**Unit** (9 passing, 1 skipped): JWT claims/expiry, worker-callback shared-secret auth, segment persistence + speaker seeding + status/SignalR notify, blank-label→UNKNOWN, failure handling, transcription versioning, model selection, ownership scoping.

**Integration** (7 passing): EF migrations apply, `vector(768)` round-trip, FK-to-AspNetUsers enforcement, the highest-version filtered-`Include` rule (skipped in unit, verified here), Redis stream PascalCase wire contract, and MinIO upload/read/presigned-URL round-trips.

## Notes
- The one in-memory-skipped test (`Get_ReturnsOnlyHighestVersionTranscription`) is genuinely verified in the integration suite — the in-memory provider does not translate filtered-`Include` ordering or enforce FKs.
- `dotnet test tests/Diariz.Api.Tests` is the fast, Docker-free inner loop; the full `dotnet test` includes the integration project and requires Docker.

## Test plan
- [x] `dotnet build Diariz.slnx` — succeeded, 0 warnings
- [x] `dotnet test tests/Diariz.Api.Tests` — 9 passed, 1 skipped
- [x] `dotnet test tests/Diariz.Api.IntegrationTests` — 7 passed (Docker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)