### PR TITLE
Add Auth + Recordings test coverage; fix RenameSpeaker insert bug

### DIFF
--- a/src/Diariz.Api/Controllers/RecordingsController.cs
+++ b/src/Diariz.Api/Controllers/RecordingsController.cs
@@ -120,8 +120,11 @@ public class RecordingsController : ControllerBase
         var speaker = rec.Speakers.FirstOrDefault(s => s.Label == req.Label);
         if (speaker is null)
         {
+            // Add to the DbSet (not the loaded nav collection) so EF tracks it as Added/INSERT.
+            // Adding via rec.Speakers leaves the new row in the wrong state and SaveChanges
+            // emits an UPDATE that affects 0 rows -> DbUpdateConcurrencyException.
             speaker = new Speaker { Id = Guid.NewGuid(), RecordingId = rec.Id, Label = req.Label };
-            rec.Speakers.Add(speaker);
+            _db.Speakers.Add(speaker);
         }
         speaker.DisplayName = req.DisplayName;
         await _db.SaveChangesAsync();

--- a/tests/Diariz.Api.IntegrationTests/RecordingsControllerIntegrationTests.cs
+++ b/tests/Diariz.Api.IntegrationTests/RecordingsControllerIntegrationTests.cs
@@ -1,0 +1,51 @@
+using Diariz.Api.Contracts;
+using Diariz.Api.Controllers;
+using Diariz.Api.IntegrationTests.Infrastructure;
+using Diariz.Api.Tests.Infrastructure;
+using Diariz.Domain.Entities;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+
+namespace Diariz.Api.IntegrationTests;
+
+[Collection(IntegrationCollection.Name)]
+public class RecordingsControllerIntegrationTests(ContainersFixture fx)
+{
+    private static RecordingsController Build(Diariz.Domain.DiarizDbContext db, Guid userId)
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?> { ["Transcription:DefaultModel"] = "whisperx-large-v3" })
+            .Build();
+        return new RecordingsController(db, new FakeAudioStorage(), new FakeJobQueue(), new FakeHubContext(), config)
+        {
+            ControllerContext = Http.Context(userId)
+        };
+    }
+
+    private async Task<(Guid userId, Guid recId)> SeedRecording()
+    {
+        await using var db = fx.CreateDbContext();
+        var user = new ApplicationUser { Id = Guid.NewGuid(), UserName = $"{Guid.NewGuid()}@x.test", Email = "u@x.test" };
+        var rec = new Recording { Id = Guid.NewGuid(), UserId = user.Id, BlobKey = "k" };
+        db.Users.Add(user);
+        db.Recordings.Add(rec);
+        await db.SaveChangesAsync();
+        return (user.Id, rec.Id);
+    }
+
+    [Fact]
+    public async Task RenameSpeaker_CreatesSpeaker_WhenLabelNotYetPresent()
+    {
+        var (userId, recId) = await SeedRecording();
+
+        await using (var db = fx.CreateDbContext())
+            Assert.IsType<NoContentResult>(
+                await Build(db, userId).RenameSpeaker(recId, new RenameSpeakerRequest("SPEAKER_07", "Bob")));
+
+        await using var verify = fx.CreateDbContext();
+        var sp = await verify.Speakers.SingleAsync(s => s.RecordingId == recId);
+        Assert.Equal("SPEAKER_07", sp.Label);
+        Assert.Equal("Bob", sp.DisplayName);
+    }
+}

--- a/tests/Diariz.Api.Tests/AuthControllerTests.cs
+++ b/tests/Diariz.Api.Tests/AuthControllerTests.cs
@@ -1,0 +1,103 @@
+using Diariz.Api.Configuration;
+using Diariz.Api.Contracts;
+using Diariz.Api.Controllers;
+using Diariz.Api.Services;
+using Diariz.Api.Tests.Infrastructure;
+using Diariz.Domain.Entities;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+
+namespace Diariz.Api.Tests;
+
+public class AuthControllerTests
+{
+    private const string GoodPassword = "Sup3rSecret!";
+
+    private static AuthController BuildController(IdentityTestHost host)
+    {
+        var tokens = new TokenService(Options.Create(new JwtOptions
+        {
+            Key = "test-signing-key-at-least-32-bytes-long!!",
+            AccessTokenMinutes = 60
+        }));
+        return new AuthController(host.Users, tokens);
+    }
+
+    [Fact]
+    public async Task Register_WithValidCredentials_ReturnsTokenAndPersistsUser()
+    {
+        using var host = new IdentityTestHost();
+        var controller = BuildController(host);
+
+        var result = await controller.Register(new RegisterRequest("new@user.test", GoodPassword));
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        var auth = Assert.IsType<AuthResponse>(ok.Value);
+        Assert.False(string.IsNullOrWhiteSpace(auth.AccessToken));
+
+        Assert.NotNull(await host.Users.FindByEmailAsync("new@user.test"));
+    }
+
+    [Fact]
+    public async Task Register_WithWeakPassword_ReturnsBadRequestAndCreatesNoUser()
+    {
+        using var host = new IdentityTestHost();
+        var controller = BuildController(host);
+
+        var result = await controller.Register(new RegisterRequest("weak@user.test", "short"));
+
+        var bad = Assert.IsType<BadRequestObjectResult>(result);
+        Assert.IsAssignableFrom<IEnumerable<string>>(bad.Value); // Identity error descriptions
+        Assert.Null(await host.Users.FindByEmailAsync("weak@user.test"));
+    }
+
+    [Fact]
+    public async Task Register_DuplicateEmail_ReturnsBadRequest()
+    {
+        using var host = new IdentityTestHost();
+        var controller = BuildController(host);
+        await controller.Register(new RegisterRequest("dupe@user.test", GoodPassword));
+
+        var result = await controller.Register(new RegisterRequest("dupe@user.test", GoodPassword));
+
+        Assert.IsType<BadRequestObjectResult>(result);
+        Assert.Equal(1, await host.Users.Users.CountAsync(u => u.Email == "dupe@user.test"));
+    }
+
+    [Fact]
+    public async Task Login_WithCorrectPassword_ReturnsToken()
+    {
+        using var host = new IdentityTestHost();
+        var controller = BuildController(host);
+        await controller.Register(new RegisterRequest("login@user.test", GoodPassword));
+
+        var result = await controller.Login(new LoginRequest("login@user.test", GoodPassword));
+
+        var ok = Assert.IsType<OkObjectResult>(result);
+        Assert.IsType<AuthResponse>(ok.Value);
+    }
+
+    [Fact]
+    public async Task Login_WithWrongPassword_ReturnsUnauthorized()
+    {
+        using var host = new IdentityTestHost();
+        var controller = BuildController(host);
+        await controller.Register(new RegisterRequest("login2@user.test", GoodPassword));
+
+        var result = await controller.Login(new LoginRequest("login2@user.test", "WrongPassword!"));
+
+        Assert.IsType<UnauthorizedResult>(result);
+    }
+
+    [Fact]
+    public async Task Login_UnknownEmail_ReturnsUnauthorized()
+    {
+        using var host = new IdentityTestHost();
+        var controller = BuildController(host);
+
+        var result = await controller.Login(new LoginRequest("ghost@user.test", GoodPassword));
+
+        Assert.IsType<UnauthorizedResult>(result);
+    }
+}

--- a/tests/Diariz.Api.Tests/Infrastructure/IdentityTestHost.cs
+++ b/tests/Diariz.Api.Tests/Infrastructure/IdentityTestHost.cs
@@ -1,0 +1,40 @@
+using Diariz.Domain;
+using Diariz.Domain.Entities;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Diariz.Api.Tests.Infrastructure;
+
+/// <summary>
+/// Builds a real <see cref="UserManager{ApplicationUser}"/> backed by the EF in-memory provider,
+/// mirroring the Identity configuration in <c>Program.cs</c> (8-char passwords, unique email).
+/// Lets <see cref="Diariz.Api.Controllers.AuthController"/> be tested with genuine password hashing
+/// and validation instead of mocks. Dispose to release the service provider / in-memory database.
+/// </summary>
+public sealed class IdentityTestHost : IDisposable
+{
+    private readonly ServiceProvider _sp;
+    public UserManager<ApplicationUser> Users { get; }
+    public DiarizDbContext Db { get; }
+
+    public IdentityTestHost()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddDbContext<DiarizDbContext>(o => o.UseInMemoryDatabase($"diariz-identity-{Guid.NewGuid()}"));
+        services.AddIdentityCore<ApplicationUser>(o =>
+            {
+                o.Password.RequiredLength = 8;
+                o.User.RequireUniqueEmail = true;
+            })
+            .AddRoles<IdentityRole<Guid>>()
+            .AddEntityFrameworkStores<DiarizDbContext>();
+
+        _sp = services.BuildServiceProvider();
+        Users = _sp.GetRequiredService<UserManager<ApplicationUser>>();
+        Db = _sp.GetRequiredService<DiarizDbContext>();
+    }
+
+    public void Dispose() => _sp.Dispose();
+}

--- a/tests/Diariz.Api.Tests/RecordingsControllerTests.cs
+++ b/tests/Diariz.Api.Tests/RecordingsControllerTests.cs
@@ -1,8 +1,10 @@
+using System.Text;
 using Diariz.Api.Controllers;
 using Diariz.Api.Tests.Infrastructure;
 using Diariz.Domain;
 using Diariz.Domain.Entities;
 using Diariz.Api.Contracts;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
@@ -107,5 +109,152 @@ public class RecordingsControllerTests
 
         var dto = Assert.IsType<RecordingDetailDto>(result.Value);
         Assert.Equal(3, dto.Current!.Version);
+    }
+
+    // ---- Upload ----
+
+    private static FormFile FakeAudio(byte[]? bytes = null, string fileName = "recording.webm", string contentType = "audio/webm")
+    {
+        bytes ??= Encoding.UTF8.GetBytes("pretend-audio");
+        return new FormFile(new MemoryStream(bytes), 0, bytes.Length, "audio", fileName)
+        {
+            Headers = new HeaderDictionary(),
+            ContentType = contentType
+        };
+    }
+
+    [Fact]
+    public async Task Upload_StoresBlob_PersistsRecording_AndEnqueuesFirstTranscription()
+    {
+        using var db = TestDb.Create();
+        var userId = Guid.NewGuid();
+        var queue = new FakeJobQueue();
+        var storage = new FakeAudioStorage();
+        var controller = Build(db, userId, queue, storage);
+        var bytes = Encoding.UTF8.GetBytes("hello-audio-bytes");
+
+        var result = await controller.Upload(FakeAudio(bytes), title: "Standup", durationMs: 4200);
+
+        var created = Assert.IsType<CreatedAtActionResult>(result.Result);
+        var summary = Assert.IsType<RecordingSummaryDto>(created.Value);
+        Assert.Equal("Standup", summary.Title);
+        Assert.Equal(RecordingStatus.Queued, summary.Status);
+
+        var rec = await db.Recordings.SingleAsync();
+        Assert.Equal(userId, rec.UserId);
+        Assert.Equal(4200, rec.DurationMs);
+        Assert.True(storage.Objects.ContainsKey(rec.BlobKey));
+        Assert.Equal(bytes, storage.Objects[rec.BlobKey]);
+
+        var tr = await db.Transcriptions.SingleAsync(t => t.RecordingId == rec.Id);
+        Assert.Equal(1, tr.Version);
+        var job = Assert.Single(queue.Enqueued);
+        Assert.Equal(rec.Id, job.RecordingId);
+        Assert.Equal(tr.Id, job.TranscriptionId);
+    }
+
+    [Fact]
+    public async Task Upload_EmptyFile_ReturnsBadRequest_AndStoresNothing()
+    {
+        using var db = TestDb.Create();
+        var queue = new FakeJobQueue();
+        var storage = new FakeAudioStorage();
+        var controller = Build(db, Guid.NewGuid(), queue, storage);
+
+        var result = await controller.Upload(FakeAudio(Array.Empty<byte>()), title: "x", durationMs: 0);
+
+        Assert.IsType<BadRequestObjectResult>(result.Result);
+        Assert.Empty(await db.Recordings.ToListAsync());
+        Assert.Empty(queue.Enqueued);
+        Assert.Empty(storage.Objects);
+    }
+
+    [Fact]
+    public async Task Upload_BlankTitle_GetsGeneratedDefaultTitle()
+    {
+        using var db = TestDb.Create();
+        var controller = Build(db, Guid.NewGuid(), new FakeJobQueue());
+
+        var result = await controller.Upload(FakeAudio(), title: null, durationMs: 1000);
+
+        var summary = Assert.IsType<RecordingSummaryDto>(Assert.IsType<CreatedAtActionResult>(result.Result).Value);
+        Assert.StartsWith("Recording ", summary.Title);
+    }
+
+    // ---- RenameSpeaker ----
+
+    [Fact]
+    public async Task RenameSpeaker_UpdatesExistingSpeakerDisplayName()
+    {
+        using var db = TestDb.Create();
+        var userId = Guid.NewGuid();
+        var rec = await SeedRecording(db, userId, versions: 1);
+        db.Speakers.Add(new Speaker { Id = Guid.NewGuid(), RecordingId = rec.Id, Label = "SPEAKER_00", DisplayName = "SPEAKER_00" });
+        await db.SaveChangesAsync();
+        var controller = Build(db, userId, new FakeJobQueue());
+
+        var result = await controller.RenameSpeaker(rec.Id, new RenameSpeakerRequest("SPEAKER_00", "Alice"));
+
+        Assert.IsType<NoContentResult>(result);
+        var sp = await db.Speakers.SingleAsync(s => s.RecordingId == rec.Id && s.Label == "SPEAKER_00");
+        Assert.Equal("Alice", sp.DisplayName);
+    }
+
+    [Fact]
+    public async Task RenameSpeaker_CreatesSpeaker_WhenLabelNotYetPresent()
+    {
+        using var db = TestDb.Create();
+        var userId = Guid.NewGuid();
+        var rec = await SeedRecording(db, userId, versions: 1);
+        var controller = Build(db, userId, new FakeJobQueue());
+
+        var result = await controller.RenameSpeaker(rec.Id, new RenameSpeakerRequest("SPEAKER_07", "Bob"));
+
+        Assert.IsType<NoContentResult>(result);
+        var sp = await db.Speakers.SingleAsync(s => s.RecordingId == rec.Id);
+        Assert.Equal("SPEAKER_07", sp.Label);
+        Assert.Equal("Bob", sp.DisplayName);
+    }
+
+    [Fact]
+    public async Task RenameSpeaker_OnAnotherUsersRecording_ReturnsNotFound()
+    {
+        using var db = TestDb.Create();
+        var rec = await SeedRecording(db, Guid.NewGuid(), versions: 1);
+        var controller = Build(db, userId: Guid.NewGuid(), new FakeJobQueue());
+
+        var result = await controller.RenameSpeaker(rec.Id, new RenameSpeakerRequest("SPEAKER_00", "X"));
+
+        Assert.IsType<NotFoundResult>(result);
+    }
+
+    // ---- AudioUrl ----
+
+    [Fact]
+    public async Task AudioUrl_ReturnsPresignedUrl_ForOwnedRecording()
+    {
+        using var db = TestDb.Create();
+        var userId = Guid.NewGuid();
+        var storage = new FakeAudioStorage { PresignedUrl = "https://minio.test/recordings/abc?sig=1" };
+        var rec = await SeedRecording(db, userId, versions: 1);
+        var controller = Build(db, userId, new FakeJobQueue(), storage);
+
+        var result = await controller.AudioUrl(rec.Id);
+
+        Assert.Null(result.Result); // not a NotFound
+        var url = result.Value!.GetType().GetProperty("url")!.GetValue(result.Value);
+        Assert.Equal(storage.PresignedUrl, url);
+    }
+
+    [Fact]
+    public async Task AudioUrl_OnAnotherUsersRecording_ReturnsNotFound()
+    {
+        using var db = TestDb.Create();
+        var rec = await SeedRecording(db, Guid.NewGuid(), versions: 1);
+        var controller = Build(db, userId: Guid.NewGuid(), new FakeJobQueue());
+
+        var result = await controller.AudioUrl(rec.Id);
+
+        Assert.IsType<NotFoundResult>(result.Result);
     }
 }


### PR DESCRIPTION
## Summary
Extends the .NET test harness to the previously untested controller surface (`AuthController` and the rest of `RecordingsController`) — and the new tests surfaced a **real production bug**, now fixed.

## 🐛 Bug found & fixed
`RecordingsController.RenameSpeaker` added a brand-new `Speaker` via the loaded **navigation collection** (`rec.Speakers.Add`), which EF tracked as a modification. `SaveChanges` then issued an `UPDATE` affecting 0 rows and threw `DbUpdateConcurrencyException` — so **renaming any speaker label that didn't already have a `Speaker` row returned a 500**. Fixed by adding through the `DbSet` (`_db.Speakers.Add`), matching the working pattern in `WorkerCallbackController`. Reproduced and verified fixed on **both** the in-memory and real-Postgres providers.

## Coverage added
**AuthController** (unit, real `UserManager` over in-memory via `IdentityTestHost`):
- register: success / weak password → BadRequest / duplicate email → BadRequest
- login: correct → token / wrong password → 401 / unknown email → 401

**RecordingsController** (unit):
- `Upload`: blob stored + recording persisted + first transcription enqueued; empty file → BadRequest (stores nothing); blank title → generated default
- `RenameSpeaker`: update existing / create new / another user's recording → NotFound
- `AudioUrl`: presigned URL for owner / another user's recording → NotFound

**RecordingsController** (integration): the `RenameSpeaker` create-new path against real Postgres (the test that first proved the bug was real, not a provider quirk).

## Test plan
- [x] `dotnet build Diariz.slnx` — 0 warnings
- [x] `dotnet test tests/Diariz.Api.Tests` — 23 passed, 1 skipped
- [x] `dotnet test tests/Diariz.Api.IntegrationTests` — 8 passed (Docker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)