### PR TITLE
Add Python worker test harness (pytest) + tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -354,6 +354,10 @@ paket-files/
 **/__pycache__/
 *.pyc
 
+# Python virtualenvs and test caches
+**/.venv/
+**/.pytest_cache/
+
 # Cake - Uncomment if you are using it
 #tools/**
 #!tools/packages.config

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,6 +135,12 @@ HF_TOKEN=... REDIS_URL=redis://localhost:6379/0 API_BASE_URL=http://localhost:80
 Diarization is gated: you **must** set `HF_TOKEN` and accept the `pyannote/speaker-diarization-3.1`
 + `pyannote/segmentation-3.0` terms on Hugging Face, or jobs fail. CPU-only: `DEVICE=cpu COMPUTE_TYPE=int8` (slow).
 
+Worker tests (pytest, no GPU): `pip install -r requirements-test.txt && python -m pytest`. The suite
+stubs `whisperx` (`tests/conftest.py`) so `torch`/CUDA aren't needed — it covers the callback contract
+(`callback.py`), job orchestration + temp cleanup (`worker.handle`), and segment shaping
+(`pipeline._shape_segments`). The shaping logic is extracted into `_shape_segments` precisely so it can
+be unit-tested without the models; keep new pure transforms similarly separable from the whisperx calls.
+
 ### Web
 ```bash
 cd apps/web
@@ -170,9 +176,8 @@ out the `deploy.resources` GPU block and set `WORKER_DEVICE=cpu WORKER_COMPUTE_T
 
 ## Conventions & gotchas
 
-- **Tests:** the .NET harness (`tests/Diariz.Api.Tests` + integration) and the web `vitest` harness
-  exist (see above). The **Python worker** does **not** have a test harness yet — add `pytest` when
-  working in it.
+- **Tests:** harnesses exist for all three stacks — .NET (`tests/Diariz.Api.Tests` + integration),
+  web (`vitest`), and the Python worker (`pytest`, see the Worker section). No CI runs them on push yet.
 - **Ports:** API `8080`; web UI (Docker/nginx) `8081`; web dev server `5173`; Postgres `5432`;
   Redis `6379`; **MinIO is remapped on the host**
   — S3 API `9002→9000`, console `9003→9001` (avoids clashing with other local MinIO instances).

--- a/src/Diariz.Worker/README.md
+++ b/src/Diariz.Worker/README.md
@@ -28,3 +28,15 @@ pip install torch torchaudio --index-url https://download.pytorch.org/whl/cu121
 pip install -r requirements.txt
 HF_TOKEN=... REDIS_URL=redis://localhost:6379/0 API_BASE_URL=http://localhost:8080 python worker.py
 ```
+
+## Tests
+
+Fast, GPU-free unit tests (pytest). `whisperx`/`torch` are **not** required — the suite stubs
+`whisperx` (see `tests/conftest.py`), so it covers the callback contract, the job
+orchestration/cleanup in `worker.handle`, and the segment-shaping in `pipeline._shape_segments`.
+
+```bash
+python -m venv .venv
+.venv/Scripts/python -m pip install -r requirements-test.txt   # Linux/macOS: .venv/bin/python
+.venv/Scripts/python -m pytest
+```

--- a/src/Diariz.Worker/conftest.py
+++ b/src/Diariz.Worker/conftest.py
@@ -1,0 +1,15 @@
+"""Shared pytest setup for the worker tests.
+
+Worker modules (config, callback, worker, pipeline, storage) are top-level modules
+that live next to this file, so put this directory on the import path. `whisperx`
+(and its torch/CUDA dependencies) is GPU-only and not installed in the test env;
+`pipeline.py` imports it at module load, so stub it before any test imports the
+worker modules. The logic under test never calls into the real models.
+"""
+import os
+import sys
+from unittest.mock import MagicMock
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+sys.modules.setdefault("whisperx", MagicMock())

--- a/src/Diariz.Worker/pipeline.py
+++ b/src/Diariz.Worker/pipeline.py
@@ -45,6 +45,23 @@ def _get_diarizer():
     return _diarize_model
 
 
+def _shape_segments(raw_segments: list[dict]) -> list[dict]:
+    """Convert whisperx segments to the API's contract: PascalCase keys, seconds -> ms,
+    empty-text segments dropped, missing speaker defaulted to UNKNOWN."""
+    segments = []
+    for seg in raw_segments:
+        text = (seg.get("text") or "").strip()
+        if not text:
+            continue
+        segments.append({
+            "Speaker": seg.get("speaker", "UNKNOWN"),
+            "StartMs": int(round(seg["start"] * 1000)),
+            "EndMs": int(round(seg["end"] * 1000)),
+            "Text": text,
+        })
+    return segments
+
+
 def transcribe(audio_path: str) -> dict:
     """Run transcription -> alignment -> diarization. Returns {language, segments}."""
     audio = whisperx.load_audio(audio_path)
@@ -63,16 +80,4 @@ def transcribe(audio_path: str) -> dict:
     diarize_segments = _get_diarizer()(audio)
     result = whisperx.assign_word_speakers(diarize_segments, result)
 
-    segments = []
-    for seg in result["segments"]:
-        text = (seg.get("text") or "").strip()
-        if not text:
-            continue
-        segments.append({
-            "Speaker": seg.get("speaker", "UNKNOWN"),
-            "StartMs": int(round(seg["start"] * 1000)),
-            "EndMs": int(round(seg["end"] * 1000)),
-            "Text": text,
-        })
-
-    return {"language": language, "segments": segments}
+    return {"language": language, "segments": _shape_segments(result["segments"])}

--- a/src/Diariz.Worker/pytest.ini
+++ b/src/Diariz.Worker/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = tests
+python_files = test_*.py

--- a/src/Diariz.Worker/requirements-test.txt
+++ b/src/Diariz.Worker/requirements-test.txt
@@ -1,0 +1,9 @@
+# Test-only dependencies for the worker. Lets you run `pytest` without a GPU:
+# whisperx/torch are NOT installed here — the test suite stubs `whisperx` (see
+# tests/conftest.py) because the segment-shaping/orchestration logic under test
+# does not need the models. The lightweight runtime deps below are installed for
+# real so module imports (callback/worker/storage/config) are exercised as shipped.
+pytest==8.3.4
+requests==2.32.3
+redis==5.2.1
+boto3==1.35.99

--- a/src/Diariz.Worker/tests/test_callback.py
+++ b/src/Diariz.Worker/tests/test_callback.py
@@ -1,0 +1,66 @@
+"""Tests for the worker -> API callback contract (callback.py)."""
+import pytest
+
+import callback
+
+
+class _OkResponse:
+    def raise_for_status(self):
+        pass
+
+
+class _ErrorResponse:
+    def raise_for_status(self):
+        raise RuntimeError("HTTP 500")
+
+
+def test_post_result_sends_pascalcase_body_and_secret_header(monkeypatch):
+    captured = {}
+
+    def fake_post(url, json=None, headers=None, timeout=None):
+        captured.update(url=url, json=json, headers=headers, timeout=timeout)
+        return _OkResponse()
+
+    monkeypatch.setattr(callback.requests, "post", fake_post)
+
+    segments = [{"Speaker": "SPEAKER_00", "StartMs": 0, "EndMs": 1000, "Text": "hi"}]
+    callback.post_result("tid-1", "en", segments)
+
+    assert captured["url"].endswith("/internal/transcriptions/result")
+    # The .NET WorkerCallbackController binds these PascalCase keys exactly.
+    assert captured["json"] == {
+        "TranscriptionId": "tid-1",
+        "Language": "en",
+        "Segments": segments,
+    }
+    assert captured["headers"]["X-Worker-Secret"] == callback.config.CALLBACK_SECRET
+
+
+def test_post_result_raises_on_http_error(monkeypatch):
+    monkeypatch.setattr(callback.requests, "post", lambda *a, **k: _ErrorResponse())
+    with pytest.raises(RuntimeError):
+        callback.post_result("tid-1", "en", [])
+
+
+def test_post_failure_truncates_error_to_2000_chars(monkeypatch):
+    captured = {}
+
+    def fake_post(url, json=None, headers=None, timeout=None):
+        captured.update(json=json)
+        return _OkResponse()
+
+    monkeypatch.setattr(callback.requests, "post", fake_post)
+
+    callback.post_failure("tid-9", "x" * 5000)
+
+    assert captured["json"]["TranscriptionId"] == "tid-9"
+    assert len(captured["json"]["Error"]) == 2000
+
+
+def test_post_failure_swallows_exceptions(monkeypatch):
+    # Failure reporting is best-effort and must never raise.
+    def boom(*a, **k):
+        raise ConnectionError("api down")
+
+    monkeypatch.setattr(callback.requests, "post", boom)
+    callback.post_failure("tid-9", "some error")  # no exception => pass

--- a/src/Diariz.Worker/tests/test_pipeline.py
+++ b/src/Diariz.Worker/tests/test_pipeline.py
@@ -1,0 +1,31 @@
+"""Tests for the segment-shaping contract in pipeline._shape_segments()."""
+import pipeline
+
+
+def test_converts_seconds_to_ms_and_keeps_pascalcase_keys():
+    raw = [{"text": " Hello world ", "speaker": "SPEAKER_00", "start": 1.2, "end": 2.5}]
+    assert pipeline._shape_segments(raw) == [
+        {"Speaker": "SPEAKER_00", "StartMs": 1200, "EndMs": 2500, "Text": "Hello world"}
+    ]
+
+
+def test_drops_empty_and_whitespace_only_segments():
+    raw = [
+        {"text": "   ", "speaker": "S", "start": 0, "end": 1},
+        {"text": None, "speaker": "S", "start": 1, "end": 2},
+        {"text": "real", "speaker": "S", "start": 2, "end": 3},
+    ]
+    shaped = pipeline._shape_segments(raw)
+    assert [s["Text"] for s in shaped] == ["real"]
+
+
+def test_defaults_missing_speaker_to_unknown():
+    raw = [{"text": "hi", "start": 0.0, "end": 0.4}]  # no "speaker" key
+    assert pipeline._shape_segments(raw)[0]["Speaker"] == "UNKNOWN"
+
+
+def test_rounds_milliseconds():
+    raw = [{"text": "x", "speaker": "S", "start": 0.0014, "end": 0.0016}]
+    out = pipeline._shape_segments(raw)[0]
+    assert out["StartMs"] == 1  # 1.4 ms -> 1
+    assert out["EndMs"] == 2    # 1.6 ms -> 2

--- a/src/Diariz.Worker/tests/test_worker.py
+++ b/src/Diariz.Worker/tests/test_worker.py
@@ -1,0 +1,67 @@
+"""Tests for the job orchestration + temp-file cleanup in worker.handle()."""
+import os
+
+import worker
+
+
+def _job(transcription_id="tid-1"):
+    return {"TranscriptionId": transcription_id, "BlobKey": "user/blob.wav", "Model": "whisperx-large-v3"}
+
+
+def test_handle_success_posts_result_and_removes_temp_file(monkeypatch, tmp_path):
+    audio = tmp_path / "audio.wav"
+    audio.write_text("fake")
+    monkeypatch.setattr(worker.storage, "download", lambda key: str(audio))
+    monkeypatch.setattr(worker.pipeline, "transcribe",
+                        lambda path: {"language": "en", "segments": [{"Text": "hi"}]})
+
+    posted = {}
+    monkeypatch.setattr(worker.callback, "post_result",
+                        lambda tid, lang, segs: posted.update(tid=tid, lang=lang, segs=segs))
+    monkeypatch.setattr(worker.callback, "post_failure",
+                        lambda *a, **k: posted.update(failed=True))
+
+    worker.handle(_job("tid-1"))
+
+    assert posted["tid"] == "tid-1"
+    assert posted["lang"] == "en"
+    assert "failed" not in posted
+    assert not os.path.exists(str(audio))  # temp file cleaned up
+
+
+def test_handle_transcribe_failure_reports_failure_and_cleans_temp(monkeypatch, tmp_path):
+    audio = tmp_path / "audio.wav"
+    audio.write_text("fake")
+    monkeypatch.setattr(worker.storage, "download", lambda key: str(audio))
+
+    def boom(path):
+        raise RuntimeError("model exploded")
+
+    monkeypatch.setattr(worker.pipeline, "transcribe", boom)
+
+    outcome = {}
+    monkeypatch.setattr(worker.callback, "post_result", lambda *a, **k: outcome.update(result=True))
+    monkeypatch.setattr(worker.callback, "post_failure", lambda tid, err: outcome.update(tid=tid, err=err))
+
+    worker.handle(_job("tid-2"))
+
+    assert outcome["tid"] == "tid-2"
+    assert "model exploded" in outcome["err"]
+    assert "result" not in outcome
+    assert not os.path.exists(str(audio))
+
+
+def test_handle_download_failure_reports_failure_without_crashing(monkeypatch):
+    def boom(key):
+        raise IOError("blob missing")
+
+    monkeypatch.setattr(worker.storage, "download", boom)
+
+    outcome = {}
+    monkeypatch.setattr(worker.callback, "post_result", lambda *a, **k: outcome.update(result=True))
+    monkeypatch.setattr(worker.callback, "post_failure", lambda tid, err: outcome.update(tid=tid, err=err))
+
+    worker.handle(_job("tid-3"))
+
+    assert outcome["tid"] == "tid-3"
+    assert "result" not in outcome


### PR DESCRIPTION
Stands up a fast, **GPU-free** pytest harness for the transcription worker and covers its core logic — completing test coverage across all three stacks (.NET, web, Python).

## Approach
`whisperx`/`torch` are GPU-only and not needed to test the worker's logic. `tests/conftest.py` stubs `whisperx` (which `pipeline.py` imports at module load), and `requirements-test.txt` installs only the lightweight runtime deps (`requests`, `redis`, `boto3`) so module imports run exactly as shipped.

```bash
cd src/Diariz.Worker
python -m venv .venv
.venv/Scripts/python -m pip install -r requirements-test.txt
.venv/Scripts/python -m pytest
```

## Coverage (11 tests)
- **callback.py** — `post_result` sends the PascalCase contract (`TranscriptionId`/`Language`/`Segments`) to the right URL with the `X-Worker-Secret` header and raises on HTTP error; `post_failure` truncates the error to 2000 chars and is best-effort (never raises). Mirrors the .NET `WorkerCallbackController` side.
- **worker.handle** — success posts the result and removes the temp file; both transcribe-failure and download-failure report via `post_failure` and still clean up, without crashing the consume loop.
- **pipeline._shape_segments** — seconds→ms (rounded), empty/whitespace text dropped, missing speaker → `UNKNOWN`, PascalCase keys.

## Refactor
Extracted the segment-shaping loop out of `pipeline.transcribe` into a pure `_shape_segments()` helper so it's testable without the models (behaviour-preserving). Added `.venv`/`.pytest_cache` to `.gitignore`; documented in the worker README and CLAUDE.md.

## Test plan
- [x] `python -m pytest` (src/Diariz.Worker) — 11 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)