### PR TITLE
Fix transcription on Blackwell GPUs + re-transcribe UI/status bugs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,10 +128,19 @@ dotnet ef migrations add <Name> --project src/Diariz.Domain --startup-project sr
 ### Worker (Python)
 ```bash
 cd src/Diariz.Worker
-pip install torch torchaudio --index-url https://download.pytorch.org/whl/cu121
+pip install torch==2.7.1 torchaudio==2.7.1 --index-url https://download.pytorch.org/whl/cu128
 pip install -r requirements.txt
 HF_TOKEN=... REDIS_URL=redis://localhost:6379/0 API_BASE_URL=http://localhost:8080 python worker.py
 ```
+**GPU compatibility (Blackwell / RTX 50-series, sm_120).** The worker pins the **cu128** torch
+stack (CUDA 12.8 base image) because cu121/torch 2.5 only compiles kernels up to sm_90 — on a 5090
+every job dies at model load with *"no kernel image is available for execution on the device"*. Three
+non-obvious pins make whisperx 3.3.1 work on this stack (see `Dockerfile` / `requirements.txt`):
+`ctranslate2==4.6.3` (first version with sm_120 / CUDA 12.8; whisperx caps it at <4.5.0 so the
+Dockerfile force-installs it), `transformers==4.48.0` + `huggingface_hub==0.27.1` (hub 1.0 removed the
+`use_auth_token` kwarg pyannote 3.3.2 still passes), and `worker.py` calls `torch_compat` to restore
+`torch.load(weights_only=False)` (torch≥2.6 flipped the default and rejects the pyannote checkpoints).
+
 Diarization is gated: you **must** set `HF_TOKEN` and accept the `pyannote/speaker-diarization-3.1`
 + `pyannote/segmentation-3.0` terms on Hugging Face, or jobs fail. CPU-only: `DEVICE=cpu COMPUTE_TYPE=int8` (slow).
 

--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -17,6 +17,8 @@
       },
       "devDependencies": {
         "@tailwindcss/vite": "^4.0.0",
+        "@testing-library/dom": "^10.4.1",
+        "@testing-library/react": "^16.3.2",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
         "@vitejs/plugin-react": "^4.3.4",
@@ -280,6 +282,16 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/template": {
@@ -1605,6 +1617,61 @@
         "react": "^18 || ^19"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1806,6 +1873,39 @@
       },
       "engines": {
         "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
       }
     },
     "node_modules/assertion-error": {
@@ -2108,6 +2208,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -2117,6 +2227,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -3029,6 +3146,16 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -3210,6 +3337,21 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
     "node_modules/proxy-from-env": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
@@ -3266,6 +3408,13 @@
       "peerDependencies": {
         "react": "^19.2.7"
       }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/react-refresh": {
       "version": "0.17.0",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -20,6 +20,8 @@
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.0.0",
+    "@testing-library/dom": "^10.4.1",
+    "@testing-library/react": "^16.3.2",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",
     "@vitejs/plugin-react": "^4.3.4",

--- a/apps/web/src/pages/RecordingDetail.test.tsx
+++ b/apps/web/src/pages/RecordingDetail.test.tsx
@@ -1,0 +1,68 @@
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter, Routes, Route } from "react-router-dom";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { RecordingDetail as RecordingDetailType } from "../lib/types";
+
+// SignalR is irrelevant to the button behaviour and needs a live server; stub it.
+vi.mock("../lib/signalr", () => ({
+  createHub: () => ({ start: () => Promise.resolve(), stop: () => Promise.resolve(), on: () => {} }),
+}));
+
+vi.mock("../lib/api", () => ({
+  api: {
+    getRecording: vi.fn(),
+    retranscribe: vi.fn(),
+    renameSpeaker: vi.fn(),
+  },
+  apiErrorMessage: (e: unknown) => String(e),
+}));
+
+import { api } from "../lib/api";
+import RecordingDetail from "./RecordingDetail";
+
+const recording: RecordingDetailType = {
+  id: "rec-123",
+  title: "Test recording",
+  durationMs: 1000,
+  status: "Transcribed",
+  error: null,
+  createdAt: new Date("2026-06-26T12:00:00Z").toISOString(),
+  speakerNames: {},
+  current: { id: "t1", model: "whisperx-large-v3", version: 1, language: "en", segments: [] },
+};
+
+function renderPage() {
+  const qc = new QueryClient({ defaultOptions: { queries: { retry: false } } });
+  return render(
+    <QueryClientProvider client={qc}>
+      <MemoryRouter initialEntries={["/recordings/rec-123"]}>
+        <Routes>
+          <Route path="/recordings/:id" element={<RecordingDetail />} />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("RecordingDetail re-transcribe button", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (api.getRecording as ReturnType<typeof vi.fn>).mockResolvedValue(recording);
+    (api.retranscribe as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+  });
+
+  it("enqueues a re-transcribe and refetches the recording so the UI reflects it", async () => {
+    renderPage();
+
+    const button = await screen.findByRole("button", { name: /re-transcribe/i });
+    await waitFor(() => expect(api.getRecording).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(button);
+
+    await waitFor(() => expect(api.retranscribe).toHaveBeenCalledWith("rec-123"));
+    // The fix: a successful enqueue must invalidate the recording query so the page
+    // refetches (status flips to Queued) instead of silently doing nothing.
+    await waitFor(() => expect(api.getRecording).toHaveBeenCalledTimes(2));
+  });
+});

--- a/apps/web/src/pages/RecordingDetail.tsx
+++ b/apps/web/src/pages/RecordingDetail.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { useParams } from "react-router-dom";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
-import { api } from "../lib/api";
+import { api, apiErrorMessage } from "../lib/api";
 import { createHub } from "../lib/signalr";
 import type { SegmentDto } from "../lib/types";
 
@@ -34,9 +34,27 @@ export default function RecordingDetail() {
     return [...set];
   }, [rec]);
 
+  const [requeuing, setRequeuing] = useState(false);
+  const [actionError, setActionError] = useState<string | null>(null);
+
   async function rename(label: string, name: string) {
     await api.renameSpeaker(id, label, name);
     qc.invalidateQueries({ queryKey: ["recording", id] });
+  }
+
+  async function retranscribe() {
+    setActionError(null);
+    setRequeuing(true);
+    try {
+      await api.retranscribe(id);
+      // Refetch so the page reflects the new queued state immediately rather than
+      // waiting on a SignalR event (which may not have delivered yet).
+      await qc.invalidateQueries({ queryKey: ["recording", id] });
+    } catch (e) {
+      setActionError(apiErrorMessage(e, "Could not start re-transcription."));
+    } finally {
+      setRequeuing(false);
+    }
   }
 
   if (!rec) return <p className="text-sm text-gray-500">Loading…</p>;
@@ -52,12 +70,17 @@ export default function RecordingDetail() {
           </p>
         </div>
         <button
-          onClick={() => api.retranscribe(id)}
-          className="rounded border px-3 py-1.5 text-sm hover:bg-gray-50"
+          onClick={retranscribe}
+          disabled={requeuing}
+          className="rounded border px-3 py-1.5 text-sm hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50"
         >
-          Re-transcribe
+          {requeuing ? "Queuing…" : "Re-transcribe"}
         </button>
       </div>
+
+      {actionError && (
+        <p className="rounded bg-red-50 p-3 text-sm text-red-700">{actionError}</p>
+      )}
 
       {rec.status === "Failed" && (
         <p className="rounded bg-red-50 p-3 text-sm text-red-700">{rec.error}</p>

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -1,9 +1,12 @@
 import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
 
 // Kept separate from vite.config.ts so the production build does not depend on vitest.
 export default defineConfig({
+  plugins: [react()], // compile JSX/TSX so React components can be rendered in tests
   test: {
     environment: "jsdom", // provides window / localStorage for the api + token helpers
+    globals: true, // enables @testing-library/react's automatic cleanup between tests
     include: ["src/**/*.test.ts", "src/**/*.test.tsx"],
   },
 });

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -99,6 +99,11 @@ services:
       DEVICE: ${WORKER_DEVICE:-cuda}
       COMPUTE_TYPE: ${WORKER_COMPUTE_TYPE:-float16}
       WHISPER_MODEL: ${WHISPER_MODEL:-large-v3}
+    volumes:
+      # Persist downloaded models (whisper large-v3, wav2vec2 align, pyannote) across
+      # container recreates so a rebuild doesn't re-download ~4GB. Covers both the torch
+      # hub cache (/root/.cache/torch) and the HF hub cache (/root/.cache/huggingface).
+      - workercache:/root/.cache
     # GPU access — requires the NVIDIA Container Toolkit on the host.
     # For CPU-only, comment this out and set WORKER_DEVICE=cpu, WORKER_COMPUTE_TYPE=int8.
     deploy:
@@ -112,3 +117,4 @@ services:
 volumes:
   pgdata:
   miniodata:
+  workercache:

--- a/src/Diariz.Api/Configuration/JsonConfig.cs
+++ b/src/Diariz.Api/Configuration/JsonConfig.cs
@@ -1,0 +1,17 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Diariz.Api.Configuration;
+
+/// <summary>
+/// Central JSON configuration for the API's HTTP responses, shared by Program.cs and tests.
+/// </summary>
+public static class JsonConfig
+{
+    public static void Apply(JsonSerializerOptions options)
+    {
+        // Serialize enums (e.g. RecordingStatus) by their string name so the web client's
+        // string-union types match the wire format instead of receiving raw numbers.
+        options.Converters.Add(new JsonStringEnumConverter());
+    }
+}

--- a/src/Diariz.Api/Controllers/WorkerCallbackController.cs
+++ b/src/Diariz.Api/Controllers/WorkerCallbackController.cs
@@ -76,6 +76,7 @@ public class WorkerCallbackController : ControllerBase
         }
 
         transcription.Recording.Status = RecordingStatus.Transcribed;
+        transcription.Recording.Error = null;  // clear any error from a prior failed attempt
         await _db.SaveChangesAsync();
         await _hub.NotifyStatusAsync(transcription.Recording.UserId, transcription.RecordingId,
             RecordingStatus.Transcribed.ToString());

--- a/src/Diariz.Api/Program.cs
+++ b/src/Diariz.Api/Program.cs
@@ -88,7 +88,8 @@ builder.Services.AddSingleton<IJobQueue, RedisJobQueue>();
 // ---- App services ----
 builder.Services.AddScoped<ITokenService, TokenService>();
 
-builder.Services.AddControllers();
+builder.Services.AddControllers()
+    .AddJsonOptions(o => JsonConfig.Apply(o.JsonSerializerOptions));
 builder.Services.AddSignalR();
 builder.Services.AddOpenApi();
 

--- a/src/Diariz.Worker/Dockerfile
+++ b/src/Diariz.Worker/Dockerfile
@@ -1,6 +1,10 @@
 # GPU-enabled transcription worker (WhisperX + pyannote).
 # Requires the NVIDIA Container Toolkit on the host to expose the GPU.
-FROM nvidia/cuda:12.1.1-cudnn8-runtime-ubuntu22.04
+#
+# CUDA 12.8 + cuDNN 9 base: required for Blackwell GPUs (RTX 50-series, sm_120).
+# The cu121/torch 2.5.1 stack only compiles kernels up to sm_90, so model load
+# fails with "no kernel image is available for execution on the device" on a 5090.
+FROM nvidia/cuda:12.8.1-cudnn-runtime-ubuntu22.04
 
 ENV DEBIAN_FRONTEND=noninteractive PYTHONUNBUFFERED=1
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -9,12 +13,17 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /app
 
-# CUDA-enabled torch first (cu121 wheels), then the rest.
-RUN pip3 install --no-cache-dir torch==2.5.1 torchaudio==2.5.1 \
-    --index-url https://download.pytorch.org/whl/cu121
+# CUDA-enabled torch first (cu128 wheels include sm_120 kernels), then the rest.
+RUN pip3 install --no-cache-dir torch==2.7.1 torchaudio==2.7.1 \
+    --index-url https://download.pytorch.org/whl/cu128
 
 COPY requirements.txt ./
 RUN pip3 install --no-cache-dir -r requirements.txt
+
+# whisperx 3.3.1 conservatively pins ctranslate2<4.5.0, but Blackwell (sm_120)
+# support only landed in ctranslate2 4.6.3 (CUDA 12.8; INT8 disabled on sm_120 so
+# the worker's float16 compute_type is the supported path). Force past the cap.
+RUN pip3 install --no-cache-dir --no-deps --force-reinstall ctranslate2==4.6.3
 
 COPY . ./
 

--- a/src/Diariz.Worker/requirements.txt
+++ b/src/Diariz.Worker/requirements.txt
@@ -1,5 +1,14 @@
 # torch / torchaudio are installed from the CUDA wheel index in the Dockerfile.
 whisperx==3.3.1
+
+# Pin the Hugging Face libs to the pre-1.0 era. whisperx 3.3.1 leaves these
+# unpinned, so a fresh build otherwise drifts to the latest majors — but
+# huggingface_hub 1.0 (Oct 2025) removed the `use_auth_token` kwarg that
+# pyannote.audio 3.3.2 still passes to hf_hub_download, and transformers>=5
+# requires huggingface_hub>=1.0. These versions keep pyannote/whisperx working.
+transformers==4.48.0
+huggingface_hub==0.27.1
+
 matplotlib==3.9.4
 redis==5.2.1
 boto3==1.35.99

--- a/src/Diariz.Worker/tests/test_torch_compat.py
+++ b/src/Diariz.Worker/tests/test_torch_compat.py
@@ -1,0 +1,52 @@
+"""Tests for the torch>=2.6 `torch.load` compatibility shim.
+
+torch 2.6 flipped `torch.load`'s `weights_only` default from False to True. The
+pyannote 3.3.2 / whisperx 3.3.1 checkpoints embed non-tensor globals (e.g.
+omegaconf ListConfig) that the strict loader refuses, so the worker restores the
+old default. The wrapper logic is pure (no real torch) so it is tested here
+without the GPU stack installed.
+"""
+from torch_compat import _default_weights_only_wrapper
+
+
+def test_wrapper_defaults_weights_only_to_false_when_absent():
+    captured = {}
+
+    def fake_load(*args, **kwargs):
+        captured.update(kwargs)
+        return "loaded"
+
+    wrapped = _default_weights_only_wrapper(fake_load, default=False)
+    result = wrapped("checkpoint.bin", map_location="cpu")
+
+    assert result == "loaded"
+    assert captured["weights_only"] is False
+    assert captured["map_location"] == "cpu"
+
+
+def test_wrapper_treats_explicit_none_as_absent():
+    # PyTorch Lightning's cloud_io._load passes `weights_only=None` through to
+    # torch.load, and torch>=2.6 treats None as True. The shim must coerce None
+    # to the restored default, not leave it for torch to reject.
+    captured = {}
+
+    def fake_load(*args, **kwargs):
+        captured.update(kwargs)
+
+    wrapped = _default_weights_only_wrapper(fake_load, default=False)
+    wrapped("checkpoint.bin", map_location="cpu", weights_only=None)
+
+    assert captured["weights_only"] is False
+
+
+def test_wrapper_preserves_explicit_weights_only():
+    captured = {}
+
+    def fake_load(*args, **kwargs):
+        captured.update(kwargs)
+
+    wrapped = _default_weights_only_wrapper(fake_load, default=False)
+    wrapped("checkpoint.bin", weights_only=True)
+
+    # An explicit, non-None caller choice must win over the restored default.
+    assert captured["weights_only"] is True

--- a/src/Diariz.Worker/torch_compat.py
+++ b/src/Diariz.Worker/torch_compat.py
@@ -1,0 +1,46 @@
+"""Compatibility shim for the torch>=2.6 `torch.load` default change.
+
+torch 2.6 flipped `torch.load`'s `weights_only` argument default from False to
+True. The pyannote 3.3.2 / whisperx 3.3.1 model checkpoints (VAD, segmentation,
+diarization) embed non-tensor globals such as `omegaconf.listconfig.ListConfig`,
+which the strict `weights_only=True` unpickler refuses with:
+
+    _pickle.UnpicklingError: Weights only load failed ... Unsupported global
+
+These are the official Hugging Face model files, loaded exactly as they were
+before the CUDA 12.8 / torch 2.7 upgrade, so restoring the pre-2.6 default of
+`weights_only=False` for them is safe. Doing it via the default (rather than
+`add_safe_globals`) resolves every embedded global at once instead of
+allowlisting them one error at a time.
+"""
+import logging
+
+log = logging.getLogger("torch_compat")
+
+_patched = False
+
+
+def _default_weights_only_wrapper(orig_load, default=False):
+    """Wrap `orig_load` so `weights_only` falls back to `default` when the caller
+    leaves it unset OR passes it as None. PyTorch Lightning's `cloud_io._load`
+    forwards `weights_only=None` to `torch.load`, and torch>=2.6 treats None as
+    True — so None must be coerced, not just the missing key. An explicit,
+    non-None caller value (e.g. True) is preserved."""
+    def _load(*args, **kwargs):
+        if kwargs.get("weights_only") is None:
+            kwargs["weights_only"] = default
+        return orig_load(*args, **kwargs)
+    return _load
+
+
+def restore_legacy_torch_load():
+    """Patch `torch.load` to default `weights_only=False` (pre-2.6 behaviour).
+    Idempotent and a no-op on torch<2.6 where the default is already False."""
+    global _patched
+    if _patched:
+        return
+    import torch  # deferred: torch is GPU-only and absent in the test env
+
+    torch.load = _default_weights_only_wrapper(torch.load, default=False)
+    _patched = True
+    log.info("Patched torch.load to default weights_only=False (torch>=2.6 compat)")

--- a/src/Diariz.Worker/worker.py
+++ b/src/Diariz.Worker/worker.py
@@ -14,6 +14,7 @@ import redis
 import callback
 import pipeline
 import storage
+import torch_compat
 from config import config
 
 logging.basicConfig(
@@ -51,6 +52,10 @@ def handle(job: dict) -> None:
 
 
 def main() -> None:
+    # Restore pre-2.6 torch.load behaviour before any model checkpoint is loaded
+    # (pyannote/whisperx checkpoints fail under torch>=2.6's weights_only=True).
+    torch_compat.restore_legacy_torch_load()
+
     r = redis.Redis.from_url(config.REDIS_URL, decode_responses=True)
     while True:
         try:

--- a/tests/Diariz.Api.Tests/JsonConfigTests.cs
+++ b/tests/Diariz.Api.Tests/JsonConfigTests.cs
@@ -1,0 +1,25 @@
+using System.Text.Json;
+using Diariz.Api.Configuration;
+using Diariz.Api.Contracts;
+using Diariz.Domain.Entities;
+
+namespace Diariz.Api.Tests;
+
+public class JsonConfigTests
+{
+    // The web client types RecordingStatus as a string union ("Transcribed", "Failed", ...).
+    // The API must serialize the enum by name, not its underlying number, or the UI shows
+    // "3" instead of "Transcribed" and never matches status === "Failed".
+    [Fact]
+    public void RecordingStatus_SerializesAsStringName_NotNumber()
+    {
+        var options = new JsonSerializerOptions();
+        JsonConfig.Apply(options);
+
+        var dto = new RecordingSummaryDto(
+            Guid.NewGuid(), "title", 0, RecordingStatus.Transcribed, DateTimeOffset.UnixEpoch);
+        var json = JsonSerializer.Serialize(dto, options);
+
+        Assert.Contains("\"Transcribed\"", json);
+    }
+}

--- a/tests/Diariz.Api.Tests/WorkerCallbackControllerTests.cs
+++ b/tests/Diariz.Api.Tests/WorkerCallbackControllerTests.cs
@@ -85,6 +85,27 @@ public class WorkerCallbackControllerTests
     }
 
     [Fact]
+    public async Task Result_ClearsStaleErrorFromPreviousFailure()
+    {
+        var (controller, db, _) = Build(presentedSecret: Secret);
+        var userId = Guid.NewGuid();
+        var (recordingId, transcriptionId) = await SeedQueuedRecording(db, userId);
+
+        // A prior attempt failed and left an error; a successful re-transcribe must clear it
+        // so the recording does not show a stale error banner after it actually succeeds.
+        var rec = await db.Recordings.FindAsync(recordingId);
+        rec!.Error = "previous attempt blew up";
+        await db.SaveChangesAsync();
+
+        await controller.Result(new TranscriptionResult(transcriptionId, "en",
+            [new SegmentResult("SPEAKER_00", 0, 1000, "Hello")]));
+
+        var refreshed = await db.Recordings.FindAsync(recordingId);
+        Assert.Equal(RecordingStatus.Transcribed, refreshed!.Status);
+        Assert.Null(refreshed.Error);
+    }
+
+    [Fact]
     public async Task Result_BlankSpeakerLabel_StoredAsUnknown()
     {
         var (controller, db, _) = Build(presentedSecret: Secret);


### PR DESCRIPTION
## Summary

Local Docker stack on an RTX 5090 recorded audio but **never produced a transcription** — and the GPU showed no activity. The worker *was* consuming every job but crashing ~1s into model load with `CUDA error: no kernel image is available for execution on the device`. Root cause: the worker shipped `torch 2.5.1+cu121`, whose compiled kernels stop at **sm_90**, while the 5090 is **sm_120** (Blackwell).

This PR moves the worker to the CUDA 12.8 / cu128 stack, adds the dependency pins whisperx 3.3.1 needs to run there, and fixes several related bugs surfaced while verifying end-to-end.

## Worker — Blackwell support
- **Dockerfile**: base image → `nvidia/cuda:12.8.1-cudnn-runtime-ubuntu22.04`; torch/torchaudio → `2.7.1` from **cu128** (ships sm_120 kernels). Force-install `ctranslate2==4.6.3` (first version with sm_120 / CUDA 12.8) past whisperx's conservative `<4.5.0` cap.
- **requirements.txt**: pin `transformers==4.48.0` + `huggingface_hub==0.27.1`. hub 1.0 (Oct 2025) removed the `use_auth_token` kwarg that pyannote.audio 3.3.2 still passes, and `transformers>=5` requires hub `>=1.0`; whisperx leaves both unpinned so a fresh build otherwise drifts to incompatible majors.
- **torch_compat.py**: restore `torch.load(weights_only=False)` for the trusted pyannote/whisperx checkpoints (torch ≥2.6 flipped the default to `True`, which rejects their embedded omegaconf objects).
- **docker-compose**: add a `workercache` volume at `/root/.cache` so container recreates don't re-download ~4GB of models.

## Bugs fixed during verification
- **Stale error banner**: the worker-callback success path set status `Transcribed` but never cleared `Recording.Error`, so a recording that succeeded *after* a prior failure still showed the old error. Now cleared on success.
- **Status serialized as a number**: the API had no `JsonStringEnumConverter`, so `RecordingStatus` went over the wire as `3` while the web types expect a string union — the detail header showed "3" and `status === "Failed"` never matched. Added a shared `JsonConfig` and wired it into `AddControllers().AddJsonOptions(...)`.
- **Re-transcribe button "did nothing"**: the handler was fire-and-forget (`onClick={() => api.retranscribe(id)}`) — no pending state, swallowed errors, and no query invalidation, so the UI never changed. Now awaits the call, shows a "Queuing…" pending state, surfaces errors, and invalidates the recording query so the page reflects the queued state immediately.

## Testing
TDD throughout (red → green):
- Worker `pytest`: `test_torch_compat.py` (14 passed).
- API unit tests: `JsonConfigTests` (status serializes by name) + callback error-clear test (25 passed / 1 pre-existing skip).
- Web: first component test via React Testing Library (wired into vitest) asserting the button enqueues **and** refetches (13 passed). `npm run build` clean.
- Verified live on the 5090: a re-transcribe runs end-to-end on the GPU and returns a real diarized segment; status now serializes as `"Transcribed"`; a forced worker recreate reuses the cache (no re-download).

🤖 Generated with [Claude Code](https://claude.com/claude-code)