### PR TITLE
Fix 413 on upload and silent empty list on expired token

### DIFF
--- a/apps/web/nginx.conf
+++ b/apps/web/nginx.conf
@@ -4,6 +4,10 @@ server {
     root /usr/share/nginx/html;
     index index.html;
 
+    # Allow large audio uploads (matches the API's 1 GiB RequestSizeLimit). nginx defaults to
+    # 1 MB, which otherwise rejects recordings over ~1 MB with 413 before they reach the API.
+    client_max_body_size 1024m;
+
     # REST API — forwarded unchanged to the API container.
     location /api/ {
         proxy_pass http://api:8080;

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -28,6 +28,23 @@ http.interceptors.request.use((config) => {
   return config;
 });
 
+/// On an expired/invalid token the API returns 401. Clear the stale token and send the user to
+/// login rather than leaving them on a silently-empty page. Exported for testing.
+export function handleAuthError(error: unknown): void {
+  if (axios.isAxiosError(error) && error.response?.status === 401) {
+    setToken(null);
+    if (window.location.pathname !== "/login") window.location.assign("/login");
+  }
+}
+
+http.interceptors.response.use(
+  (response) => response,
+  (error) => {
+    handleAuthError(error);
+    return Promise.reject(error);
+  },
+);
+
 export const api = {
   async login(email: string, password: string): Promise<AuthResponse> {
     const { data } = await http.post<AuthResponse>("/api/auth/login", { email, password });

--- a/apps/web/src/lib/authError.test.ts
+++ b/apps/web/src/lib/authError.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { handleAuthError, getToken, setToken } from "./api";
+
+const realLocation = window.location;
+
+function stubLocation(pathname: string) {
+  const assign = vi.fn();
+  Object.defineProperty(window, "location", {
+    value: { pathname, assign },
+    writable: true,
+    configurable: true,
+  });
+  return assign;
+}
+
+describe("handleAuthError", () => {
+  beforeEach(() => setToken("a-token"));
+  afterEach(() => {
+    Object.defineProperty(window, "location", { value: realLocation, configurable: true });
+  });
+
+  it("clears the token and redirects to /login on 401", () => {
+    const assign = stubLocation("/");
+    handleAuthError({ isAxiosError: true, response: { status: 401 } });
+    expect(getToken()).toBeNull();
+    expect(assign).toHaveBeenCalledWith("/login");
+  });
+
+  it("does not redirect when already on /login (avoids a loop) but still clears the token", () => {
+    const assign = stubLocation("/login");
+    handleAuthError({ isAxiosError: true, response: { status: 401 } });
+    expect(getToken()).toBeNull();
+    expect(assign).not.toHaveBeenCalled();
+  });
+
+  it("leaves the token and does not redirect on non-401 errors", () => {
+    const assign = stubLocation("/");
+    handleAuthError({ isAxiosError: true, response: { status: 500 } });
+    expect(getToken()).toBe("a-token");
+    expect(assign).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Two bugs reported after the recording-management update, both in the web/proxy layer (no backend changes).

### Bug 1 — 413 Request Entity Too Large on upload
nginx's default `client_max_body_size` is **1 MB**, so any recording over ~1 MB was rejected at the proxy with 413 **before reaching the API** (which already permits 1 GiB via `RequestSizeLimit`). Short clips happened to fit under 1 MB; longer ones didn't.

**Fix:** set `client_max_body_size 1024m;` in [nginx.conf](apps/web/nginx.conf) to match the API limit.
**Verified:** a 2 MB POST through nginx now reaches the API (400 for non-audio bytes) instead of nginx returning 413.

### Bug 2 — recordings list shows "loading" then empty
The browser's JWT had **expired** (120-min lifetime; the signing key is unchanged, so not a key change). `GET /api/recordings` returned **401**, React Query retried it ~4× (the 5–10 s delay), and the app silently fell back to an empty list. A fresh token returns all recordings, so the list logic is fine — the defect is that the SPA didn't handle 401.

**Fix:** an axios response interceptor in [api.ts](apps/web/src/lib/api.ts) that, on 401, clears the stale token and redirects to `/login`, so the user re-authenticates instead of landing on a blank page.

## Testing
- New [authError.test.ts](apps/web/src/lib/authError.test.ts): clears token + redirects on 401, no redirect loop when already on `/login`, leaves token on non-401 errors.
- Full web suite green (24 passed); `npm run build` clean.
- End-to-end on the live stack: 2 MB upload no longer 413s; the new bundle is deployed (a 401 now bounces to login).

Note: after deploying, users must hard-refresh to pick up the new bundle; they'll be redirected to login once (their old token is expired).

🤖 Generated with [Claude Code](https://claude.com/claude-code)