### PR TITLE
UI tweaks: full-width detail, segment edit, settings defaults & resizable chat

### DIFF
--- a/apps/web/src/components/SettingsModal.test.tsx
+++ b/apps/web/src/components/SettingsModal.test.tsx
@@ -26,6 +26,9 @@ describe("SettingsModal", () => {
       apiBase: "https://existing/v1",
       model: "gpt-x",
       hasApiKey: true,
+      defaultApiBase: "https://server/v1",
+      defaultModel: "server-model",
+      serverHasApiKey: true,
     });
     (api.updateUserSettings as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
   });
@@ -64,6 +67,28 @@ describe("SettingsModal", () => {
       expect(api.updateUserSettings).toHaveBeenCalledWith(
         expect.objectContaining({ apiKey: "sk-new" }),
       ),
+    );
+  });
+
+  it("shows server defaults as placeholders and does not persist them when left blank", async () => {
+    (api.getUserSettings as ReturnType<typeof vi.fn>).mockResolvedValue({
+      apiBase: null,
+      model: null,
+      hasApiKey: false,
+      defaultApiBase: "https://server/v1",
+      defaultModel: "server-model",
+      serverHasApiKey: true,
+    });
+    renderModal();
+
+    // The server default appears as a placeholder, not a value.
+    const endpoint = await screen.findByPlaceholderText(/Default: https:\/\/server\/v1/);
+    expect((endpoint as HTMLInputElement).value).toBe("");
+
+    // Submitting without changing anything must not persist the defaults as the user's own.
+    fireEvent.click(screen.getByRole("button", { name: /^save$/i }));
+    await waitFor(() =>
+      expect(api.updateUserSettings).toHaveBeenCalledWith({ apiBase: null, model: null, apiKey: null }),
     );
   });
 

--- a/apps/web/src/components/SettingsModal.tsx
+++ b/apps/web/src/components/SettingsModal.tsx
@@ -55,37 +55,51 @@ export default function SettingsModal({ onClose }: { onClose: () => void }) {
         <p className="mb-4 text-xs text-gray-500 dark:text-gray-400">
           Your own OpenAI-compatible endpoint for summaries. Leave fields blank to use the server default.
         </p>
-        <form onSubmit={(e) => { e.preventDefault(); save.mutate(); }} className="space-y-3">
+        {/* autoComplete="off" + non-login field names stop password managers treating these as
+            username/password login fields and autofilling stored credentials. */}
+        <form onSubmit={(e) => { e.preventDefault(); save.mutate(); }} className="space-y-3" autoComplete="off">
           <label className="block text-sm">
-            <span className="mb-1 block text-gray-600 dark:text-gray-300">Endpoint (base URL)</span>
+            <span className="mb-1 block text-gray-600 dark:text-gray-300">Summarisation endpoint (base URL)</span>
             <input
+              name="diariz-summary-endpoint"
+              autoComplete="off"
               value={apiBase}
               onChange={(e) => setApiBase(e.target.value)}
-              placeholder="https://api.openai.com/v1"
+              placeholder={data?.defaultApiBase ? `Default: ${data.defaultApiBase}` : "https://api.openai.com/v1"}
               className="w-full rounded border px-2 py-1 text-sm dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
             />
           </label>
           <label className="block text-sm">
-            <span className="mb-1 block text-gray-600 dark:text-gray-300">Model</span>
+            <span className="mb-1 block text-gray-600 dark:text-gray-300">Summarisation model</span>
             <input
+              name="diariz-summary-model"
+              autoComplete="off"
               value={model}
               onChange={(e) => setModel(e.target.value)}
-              placeholder="gpt-4o-mini"
+              placeholder={data?.defaultModel ? `Default: ${data.defaultModel}` : "gpt-4o-mini"}
               className="w-full rounded border px-2 py-1 text-sm dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
             />
           </label>
           <label className="block text-sm">
             <span className="mb-1 block text-gray-600 dark:text-gray-300">
-              API key
+              Summarisation API key
               {data?.hasApiKey && apiKey === null && (
                 <span className="ml-1 text-green-600 dark:text-green-400">· set</span>
               )}
             </span>
             <input
               type="password"
+              name="diariz-summary-key"
+              autoComplete="new-password"
               value={apiKey ?? ""}
               onChange={(e) => setApiKey(e.target.value)}
-              placeholder={data?.hasApiKey ? "•••••• (leave blank to keep)" : "sk-…"}
+              placeholder={
+                data?.hasApiKey
+                  ? "•••••• (leave blank to keep)"
+                  : data?.serverHasApiKey
+                    ? "Using server default (leave blank)"
+                    : "sk-…"
+              }
               className="w-full rounded border px-2 py-1 text-sm dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
             />
             {data?.hasApiKey && (

--- a/apps/web/src/components/Workspace.test.tsx
+++ b/apps/web/src/components/Workspace.test.tsx
@@ -49,4 +49,17 @@ describe("Workspace", () => {
     renderWorkspace("/recordings/rec-1");
     expect(screen.getByText("DETAIL")).toBeTruthy();
   });
+
+  it("drag-resizes the right panel and persists the width", () => {
+    renderWorkspace();
+    fireEvent.click(screen.getByRole("button", { name: /expand chat panel/i }));
+
+    const handle = screen.getByRole("separator", { name: /resize chat panel/i });
+    fireEvent.mouseDown(handle);
+    fireEvent.mouseMove(document, { clientX: 700 });
+    fireEvent.mouseUp(document);
+
+    // jsdom window.innerWidth is 1024, so width = 1024 - 700 = 324 (within clamp).
+    expect(localStorage.getItem("diariz.panels.rightWidth")).toBe("324");
+  });
 });

--- a/apps/web/src/components/Workspace.tsx
+++ b/apps/web/src/components/Workspace.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
 import { Outlet } from "react-router-dom";
 import RecordingsPanel from "./RecordingsPanel";
 import ChatPanel from "./ChatPanel";
@@ -17,11 +17,37 @@ function usePersistedBool(key: string, fallback: boolean): [boolean, (v: boolean
   ];
 }
 
+const RIGHT_WIDTH_KEY = "diariz.panels.rightWidth";
+const RIGHT_MIN = 260;
+const RIGHT_MAX = 640;
+
 /// The three-panel workspace: recordings list · selected recording (Outlet) · chat.
-/// Left and right panels collapse to a thin rail; each panel scrolls independently.
+/// Left and right panels collapse to a thin rail; the right panel is also drag-resizable.
 export default function Workspace() {
   const [leftOpen, setLeftOpen] = usePersistedBool("diariz.panels.left", true);
   const [rightOpen, setRightOpen] = usePersistedBool("diariz.panels.right", false);
+
+  const [rightWidth, setRightWidth] = useState<number>(() => {
+    const stored = Number(localStorage.getItem(RIGHT_WIDTH_KEY));
+    return stored >= RIGHT_MIN && stored <= RIGHT_MAX ? stored : 320;
+  });
+  const widthRef = useRef(rightWidth);
+  widthRef.current = rightWidth;
+
+  function startResize(e: React.MouseEvent) {
+    e.preventDefault();
+    const onMove = (ev: MouseEvent) =>
+      setRightWidth(Math.min(RIGHT_MAX, Math.max(RIGHT_MIN, window.innerWidth - ev.clientX)));
+    const onUp = () => {
+      document.removeEventListener("mousemove", onMove);
+      document.removeEventListener("mouseup", onUp);
+      document.body.style.userSelect = "";
+      localStorage.setItem(RIGHT_WIDTH_KEY, String(widthRef.current));
+    };
+    document.body.style.userSelect = "none"; // don't select text while dragging
+    document.addEventListener("mousemove", onMove);
+    document.addEventListener("mouseup", onUp);
+  }
 
   return (
     <div className="flex min-h-0 flex-1">
@@ -37,18 +63,30 @@ export default function Workspace() {
       )}
 
       <main className="min-w-0 flex-1 overflow-y-auto bg-gray-50 dark:bg-gray-950">
-        <div className="mx-auto max-w-3xl p-6">
+        <div className="p-6">
           <Outlet />
         </div>
       </main>
 
       {rightOpen ? (
-        <aside className="flex w-80 shrink-0 flex-col border-l bg-white dark:border-gray-700 dark:bg-gray-900">
-          <PanelHeader title="Chat" onCollapse={() => setRightOpen(false)} chevron="▶" />
-          <div className="min-h-0 flex-1 overflow-y-auto">
-            <ChatPanel />
-          </div>
-        </aside>
+        <div className="flex shrink-0">
+          <div
+            role="separator"
+            aria-orientation="vertical"
+            aria-label="Resize chat panel"
+            onMouseDown={startResize}
+            className="w-1 cursor-col-resize bg-transparent transition-colors hover:bg-blue-400 dark:hover:bg-blue-600"
+          />
+          <aside
+            style={{ width: rightWidth }}
+            className="flex shrink-0 flex-col border-l bg-white dark:border-gray-700 dark:bg-gray-900"
+          >
+            <PanelHeader title="Chat" onCollapse={() => setRightOpen(false)} chevron="▶" />
+            <div className="min-h-0 flex-1 overflow-y-auto">
+              <ChatPanel />
+            </div>
+          </aside>
+        </div>
       ) : (
         <CollapsedRail label="Chat" onExpand={() => setRightOpen(true)} chevron="◀" />
       )}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -83,6 +83,10 @@ export const api = {
     await http.put(`/api/recordings/${id}/speakers`, { label, displayName });
   },
 
+  async updateSegment(id: string, segmentId: string, text: string): Promise<void> {
+    await http.put(`/api/recordings/${id}/segments/${segmentId}`, { text });
+  },
+
   async renameRecording(id: string, name: string | null): Promise<void> {
     await http.put(`/api/recordings/${id}/name`, { name });
   },

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -28,6 +28,7 @@ export interface SummaryDto {
 }
 
 export interface SegmentDto {
+  id: string;
   speaker: string;
   speakerDisplay: string;
   startMs: number;
@@ -67,6 +68,10 @@ export interface UserSettings {
   apiBase: string | null;
   model: string | null;
   hasApiKey: boolean;
+  /// Server-wide defaults, shown as placeholders (applied when the user leaves a field blank).
+  defaultApiBase: string | null;
+  defaultModel: string | null;
+  serverHasApiKey: boolean;
 }
 
 export interface UpdateUserSettings {

--- a/apps/web/src/pages/RecordingDetail.test.tsx
+++ b/apps/web/src/pages/RecordingDetail.test.tsx
@@ -19,6 +19,7 @@ vi.mock("../lib/api", () => ({
     audioUrl: vi.fn(),
     downloadTranscript: vi.fn(),
     downloadAudio: vi.fn(),
+    updateSegment: vi.fn(),
   },
   apiErrorMessage: (e: unknown) => String(e),
 }));
@@ -41,7 +42,7 @@ const base: RecordingDetailType = {
     model: "whisperx-large-v3",
     version: 1,
     language: "en",
-    segments: [{ speaker: "SPEAKER_00", speakerDisplay: "Alice", startMs: 0, endMs: 1000, text: "Hi" }],
+    segments: [{ id: "seg-1", speaker: "SPEAKER_00", speakerDisplay: "Alice", startMs: 0, endMs: 1000, text: "Hi" }],
   },
   summary: null,
 };
@@ -102,7 +103,7 @@ describe("RecordingDetail", () => {
       ...base,
       current: {
         ...base.current!,
-        segments: [{ speaker: "SPEAKER_00", speakerDisplay: "Alice", startMs: 1000, endMs: 2000, text: "Hello there" }],
+        segments: [{ id: "seg-9", speaker: "SPEAKER_00", speakerDisplay: "Alice", startMs: 1000, endMs: 2000, text: "Hello there" }],
       },
     });
 
@@ -110,5 +111,20 @@ describe("RecordingDetail", () => {
 
     await waitFor(() => expect(api.audioUrl).toHaveBeenCalledWith("rec-123"));
     await waitFor(() => expect(play).toHaveBeenCalled());
+  });
+
+  it("edits a segment via its kebab and saves the new text", async () => {
+    (api.updateSegment as ReturnType<typeof vi.fn>).mockResolvedValue(undefined);
+    renderPage(base);
+    await screen.findByText("Hi");
+
+    // Open the segment's kebab → Edit, change the text, save.
+    fireEvent.click(screen.getByRole("button", { name: /segment actions/i }));
+    fireEvent.click(screen.getByRole("menuitem", { name: /edit/i }));
+    const textarea = screen.getByRole("textbox", { name: /segment text/i });
+    fireEvent.change(textarea, { target: { value: "Hi, corrected" } });
+    fireEvent.click(screen.getByRole("button", { name: /^save$/i }));
+
+    await waitFor(() => expect(api.updateSegment).toHaveBeenCalledWith("rec-123", "seg-1", "Hi, corrected"));
   });
 });

--- a/apps/web/src/pages/RecordingDetail.tsx
+++ b/apps/web/src/pages/RecordingDetail.tsx
@@ -26,6 +26,7 @@ export default function RecordingDetail() {
   const [requeuing, setRequeuing] = useState(false);
   const [summarizing, setSummarizing] = useState(false);
   const [renaming, setRenaming] = useState(false);
+  const [editingSeg, setEditingSeg] = useState<SegmentDto | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
 
   useEffect(() => {
@@ -209,10 +210,11 @@ export default function RecordingDetail() {
           <ul className="space-y-2">
             {rec.current.segments.map((s, i) => (
               <SegmentRow
-                key={i}
+                key={s.id}
                 seg={s}
                 active={i === activeIdx}
                 onPlay={() => playFrom(s.startMs)}
+                onEdit={() => setEditingSeg(s)}
               />
             ))}
           </ul>
@@ -222,6 +224,88 @@ export default function RecordingDetail() {
           No transcript yet — it appears here automatically when transcription finishes.
         </p>
       )}
+
+      {editingSeg && (
+        <SegmentEditModal
+          seg={editingSeg}
+          onClose={() => setEditingSeg(null)}
+          onSave={async (text) => {
+            await api.updateSegment(id, editingSeg.id, text);
+            setEditingSeg(null);
+            qc.invalidateQueries({ queryKey: ["recording", id] });
+          }}
+        />
+      )}
+    </div>
+  );
+}
+
+function SegmentEditModal({
+  seg,
+  onClose,
+  onSave,
+}: {
+  seg: SegmentDto;
+  onClose: () => void;
+  onSave: (text: string) => Promise<void>;
+}) {
+  const [text, setText] = useState(seg.text);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => e.key === "Escape" && onClose();
+    document.addEventListener("keydown", onKey);
+    return () => document.removeEventListener("keydown", onKey);
+  }, [onClose]);
+
+  async function save() {
+    setBusy(true);
+    setError(null);
+    try {
+      await onSave(text);
+    } catch (e) {
+      setError(apiErrorMessage(e, "Could not save the segment."));
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4" onClick={onClose}>
+      <div
+        role="dialog"
+        aria-label="Edit segment"
+        className="w-full max-w-lg rounded-lg border bg-white p-5 shadow-xl dark:border-gray-700 dark:bg-gray-900"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <h2 className="mb-3 text-base font-semibold dark:text-gray-100">Edit segment</h2>
+        <textarea
+          autoFocus
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          rows={4}
+          aria-label="Segment text"
+          className="w-full rounded border px-2 py-1 text-sm dark:border-gray-700 dark:bg-gray-800 dark:text-gray-100"
+        />
+        {error && <p className="mt-2 text-sm text-red-600 dark:text-red-400">{error}</p>}
+        <div className="mt-3 flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded border px-3 py-1.5 text-sm hover:bg-gray-50 dark:border-gray-700 dark:text-gray-200 dark:hover:bg-gray-800"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={save}
+            disabled={busy}
+            className="rounded bg-gray-900 px-3 py-1.5 text-sm text-white disabled:opacity-50 dark:bg-gray-100 dark:text-gray-900"
+          >
+            {busy ? "Saving…" : "Save"}
+          </button>
+        </div>
+      </div>
     </div>
   );
 }
@@ -287,15 +371,17 @@ function SegmentRow({
   seg,
   active,
   onPlay,
+  onEdit,
 }: {
   seg: SegmentDto;
   active: boolean;
   onPlay: () => void;
+  onEdit: () => void;
 }) {
   return (
     <li
       onClick={onPlay}
-      className={`flex cursor-pointer gap-3 rounded-lg border px-4 py-2 hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-800 ${
+      className={`flex cursor-pointer items-start gap-3 rounded-lg border px-4 py-2 hover:bg-gray-50 dark:border-gray-700 dark:hover:bg-gray-800 ${
         active
           ? "border-blue-300 bg-blue-50 dark:border-blue-700 dark:bg-blue-900/30"
           : "bg-white dark:bg-gray-900"
@@ -303,7 +389,8 @@ function SegmentRow({
     >
       <span className="w-12 shrink-0 font-mono text-xs text-gray-400 dark:text-gray-500">{fmt(seg.startMs)}</span>
       <span className="w-28 shrink-0 text-sm font-medium text-gray-700 dark:text-gray-200">{seg.speakerDisplay}</span>
-      <span className="text-sm dark:text-gray-200">{seg.text}</span>
+      <span className="flex-1 text-sm dark:text-gray-200">{seg.text}</span>
+      <KebabMenu actions={[{ label: "Edit", onClick: onEdit }]} label="Segment actions" />
     </li>
   );
 }

--- a/src/Diariz.Api/Contracts/ApiDtos.cs
+++ b/src/Diariz.Api/Contracts/ApiDtos.cs
@@ -17,7 +17,7 @@ public record RecordingSummaryDto(
     RecordingStatus Status,
     DateTimeOffset CreatedAt);
 
-public record SegmentDto(string Speaker, string SpeakerDisplay, long StartMs, long EndMs, string Text);
+public record SegmentDto(Guid Id, string Speaker, string SpeakerDisplay, long StartMs, long EndMs, string Text);
 
 public record SummaryDto(string Model, string Text, DateTimeOffset CreatedAt);
 
@@ -45,10 +45,15 @@ public record RecordingDetailDto(
 public record RenameSpeakerRequest(string Label, string DisplayName);
 public record RenameRecordingRequest(string? Name);
 public record RetranscribeRequest(string? Model);
+public record UpdateSegmentRequest(string Text);
 
 // ---- User settings (per-user summarisation config) ----
-/// <summary>Settings returned to the client. The API key is never exposed — only whether one is set.</summary>
-public record UserSettingsDto(string? ApiBase, string? Model, bool HasApiKey);
+/// <summary>Settings returned to the client. The API key is never exposed — only whether one is set.
+/// The Default* fields are the server-wide values, shown as placeholders so the user can see what
+/// applies when they leave a field blank (without those defaults being persisted as their own).</summary>
+public record UserSettingsDto(
+    string? ApiBase, string? Model, bool HasApiKey,
+    string? DefaultApiBase, string? DefaultModel, bool ServerHasApiKey);
 
 /// <summary>Update request. ApiKey is tri-state: null = leave unchanged, "" = clear, value = set.</summary>
 public record UpdateUserSettingsRequest(string? ApiBase, string? Model, string? ApiKey);

--- a/src/Diariz.Api/Controllers/RecordingsController.cs
+++ b/src/Diariz.Api/Controllers/RecordingsController.cs
@@ -67,6 +67,7 @@ public class RecordingsController : ControllerBase
         TranscriptionDto? tDto = current is null ? null : new(
             current.Id, current.Model, current.Version, current.Language, current.CreatedAt,
             current.Segments.Select(s => new SegmentDto(
+                s.Id,
                 s.SpeakerLabel,
                 names.TryGetValue(s.SpeakerLabel, out var dn) ? dn : s.SpeakerLabel,
                 s.StartMs, s.EndMs, s.Text)).ToList());
@@ -137,6 +138,22 @@ public class RecordingsController : ControllerBase
             _db.Speakers.Add(speaker);
         }
         speaker.DisplayName = req.DisplayName;
+        await _db.SaveChangesAsync();
+        return NoContent();
+    }
+
+    [HttpPut("{id:guid}/segments/{segmentId:guid}")]
+    public async Task<IActionResult> UpdateSegment(Guid id, Guid segmentId, UpdateSegmentRequest req)
+    {
+        var seg = await _db.Segments.Include(s => s.Transcription)
+            .FirstOrDefaultAsync(s => s.Id == segmentId);
+        if (seg?.Transcription is null || seg.Transcription.RecordingId != id) return NotFound();
+
+        // Ownership: the segment's recording must belong to the caller.
+        var owned = await _db.Recordings.AnyAsync(r => r.Id == id && r.UserId == UserId);
+        if (!owned) return NotFound();
+
+        seg.Text = req.Text ?? "";
         await _db.SaveChangesAsync();
         return NoContent();
     }
@@ -223,6 +240,7 @@ public class RecordingsController : ControllerBase
         var segs = current.Segments
             .OrderBy(s => s.Ordinal)
             .Select(s => new SegmentDto(
+                s.Id,
                 s.SpeakerLabel,
                 names.TryGetValue(s.SpeakerLabel, out var dn) ? dn : s.SpeakerLabel,
                 s.StartMs, s.EndMs, s.Text))

--- a/src/Diariz.Api/Controllers/UserSettingsController.cs
+++ b/src/Diariz.Api/Controllers/UserSettingsController.cs
@@ -1,10 +1,12 @@
 using System.Security.Claims;
+using Diariz.Api.Configuration;
 using Diariz.Api.Contracts;
 using Diariz.Api.Services;
 using Diariz.Domain;
 using Diariz.Domain.Entities;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
 
 namespace Diariz.Api.Controllers;
 
@@ -15,11 +17,14 @@ public class UserSettingsController : ControllerBase
 {
     private readonly DiarizDbContext _db;
     private readonly IApiKeyProtector _protector;
+    private readonly SummarizationOptions _serverDefaults;
 
-    public UserSettingsController(DiarizDbContext db, IApiKeyProtector protector)
+    public UserSettingsController(
+        DiarizDbContext db, IApiKeyProtector protector, IOptions<SummarizationOptions> serverDefaults)
     {
         _db = db;
         _protector = protector;
+        _serverDefaults = serverDefaults.Value;
     }
 
     private Guid UserId => Guid.Parse(User.FindFirstValue(ClaimTypes.NameIdentifier)!);
@@ -28,9 +33,14 @@ public class UserSettingsController : ControllerBase
     public async Task<UserSettingsDto> Get()
     {
         var s = await _db.UserSettings.FindAsync(UserId);
-        return new UserSettingsDto(s?.SummaryApiBase, s?.SummaryModel,
-            !string.IsNullOrEmpty(s?.SummaryApiKeyEncrypted));
+        return new UserSettingsDto(
+            s?.SummaryApiBase, s?.SummaryModel, !string.IsNullOrEmpty(s?.SummaryApiKeyEncrypted),
+            DefaultApiBase: NullIfBlank(_serverDefaults.ApiBase),
+            DefaultModel: NullIfBlank(_serverDefaults.Model),
+            ServerHasApiKey: !string.IsNullOrEmpty(_serverDefaults.ApiKey));
     }
+
+    private static string? NullIfBlank(string? v) => string.IsNullOrWhiteSpace(v) ? null : v;
 
     [HttpPut]
     public async Task<IActionResult> Update(UpdateUserSettingsRequest req)

--- a/src/Diariz.Api/Services/SummarizationProcessor.cs
+++ b/src/Diariz.Api/Services/SummarizationProcessor.cs
@@ -38,6 +38,7 @@ public static class SummarizationProcessor
             var segs = transcription.Segments
                 .OrderBy(s => s.Ordinal)
                 .Select(s => new SegmentDto(
+                    s.Id,
                     s.SpeakerLabel,
                     names.TryGetValue(s.SpeakerLabel, out var dn) ? dn : s.SpeakerLabel,
                     s.StartMs, s.EndMs, s.Text))

--- a/tests/Diariz.Api.IntegrationTests/UserSettingsIntegrationTests.cs
+++ b/tests/Diariz.Api.IntegrationTests/UserSettingsIntegrationTests.cs
@@ -19,7 +19,7 @@ public class UserSettingsIntegrationTests(ContainersFixture fx)
     private static readonly IApiKeyProtector Protector = new ApiKeyProtector(new EphemeralDataProtectionProvider());
 
     private static UserSettingsController Settings(Diariz.Domain.DiarizDbContext db, Guid userId) =>
-        new(db, Protector) { ControllerContext = Http.Context(userId) };
+        new(db, Protector, Options.Create(new SummarizationOptions())) { ControllerContext = Http.Context(userId) };
 
     private async Task<Guid> SeedUser()
     {

--- a/tests/Diariz.Api.Tests/RecordingsControllerTests.cs
+++ b/tests/Diariz.Api.Tests/RecordingsControllerTests.cs
@@ -236,6 +236,51 @@ public class RecordingsControllerTests
         Assert.IsType<NotFoundResult>(result);
     }
 
+    // ---- Update segment ----
+
+    [Fact]
+    public async Task UpdateSegment_UpdatesText_OnOwnedRecording()
+    {
+        using var db = TestDb.Create();
+        var userId = Guid.NewGuid();
+        var rec = await SeedTranscribedRecording(db, userId);
+        var seg = await db.Segments.FirstAsync();
+        var controller = Build(db, userId, new FakeJobQueue());
+
+        var result = await controller.UpdateSegment(rec.Id, seg.Id, new UpdateSegmentRequest("Corrected text"));
+
+        Assert.IsType<NoContentResult>(result);
+        Assert.Equal("Corrected text", (await db.Segments.FindAsync(seg.Id))!.Text);
+    }
+
+    [Fact]
+    public async Task UpdateSegment_OnAnotherUsersRecording_ReturnsNotFound()
+    {
+        using var db = TestDb.Create();
+        var rec = await SeedTranscribedRecording(db, Guid.NewGuid());
+        var seg = await db.Segments.FirstAsync();
+        var controller = Build(db, userId: Guid.NewGuid(), new FakeJobQueue());
+
+        var result = await controller.UpdateSegment(rec.Id, seg.Id, new UpdateSegmentRequest("hijack"));
+
+        Assert.IsType<NotFoundResult>(result);
+        Assert.NotEqual("hijack", (await db.Segments.FindAsync(seg.Id))!.Text);
+    }
+
+    [Fact]
+    public async Task UpdateSegment_WrongRecordingId_ReturnsNotFound()
+    {
+        using var db = TestDb.Create();
+        var userId = Guid.NewGuid();
+        await SeedTranscribedRecording(db, userId);
+        var seg = await db.Segments.FirstAsync();
+        var controller = Build(db, userId, new FakeJobQueue());
+
+        var result = await controller.UpdateSegment(Guid.NewGuid(), seg.Id, new UpdateSegmentRequest("x"));
+
+        Assert.IsType<NotFoundResult>(result);
+    }
+
     // ---- Summarize ----
 
     [Fact]

--- a/tests/Diariz.Api.Tests/SummarizationClientTests.cs
+++ b/tests/Diariz.Api.Tests/SummarizationClientTests.cs
@@ -10,7 +10,7 @@ namespace Diariz.Api.Tests;
 public class SummarizationClientTests
 {
     private static readonly IReadOnlyList<SegmentDto> Segments =
-        [new SegmentDto("SPEAKER_00", "Alice", 0, 1000, "Hello there.")];
+        [new SegmentDto(Guid.NewGuid(), "SPEAKER_00", "Alice", 0, 1000, "Hello there.")];
 
     private static string ChatResponse(string content)
     {

--- a/tests/Diariz.Api.Tests/SummarizationPromptTests.cs
+++ b/tests/Diariz.Api.Tests/SummarizationPromptTests.cs
@@ -8,8 +8,8 @@ public class SummarizationPromptTests
 {
     private static readonly IReadOnlyList<SegmentDto> Segments =
     [
-        new SegmentDto("SPEAKER_00", "Alice", 0, 1000, "We ship Friday."),
-        new SegmentDto("SPEAKER_01", "Bob", 1000, 2000, "I'll write the tests."),
+        new SegmentDto(Guid.NewGuid(), "SPEAKER_00", "Alice", 0, 1000, "We ship Friday."),
+        new SegmentDto(Guid.NewGuid(), "SPEAKER_01", "Bob", 1000, 2000, "I'll write the tests."),
     ];
 
     // Wraps model output the way an OpenAI chat-completions response does.

--- a/tests/Diariz.Api.Tests/TranscriptFormatterTests.cs
+++ b/tests/Diariz.Api.Tests/TranscriptFormatterTests.cs
@@ -7,8 +7,8 @@ public class TranscriptFormatterTests
 {
     private static readonly IReadOnlyList<SegmentDto> Segments =
     [
-        new SegmentDto("SPEAKER_00", "Alice", 852, 3896, "So here's the thing."),
-        new SegmentDto("SPEAKER_01", "Bob", 64000, 66500, "Right, on the API."),
+        new SegmentDto(Guid.NewGuid(), "SPEAKER_00", "Alice", 852, 3896, "So here's the thing."),
+        new SegmentDto(Guid.NewGuid(), "SPEAKER_01", "Bob", 64000, 66500, "Right, on the API."),
     ];
 
     [Fact]

--- a/tests/Diariz.Api.Tests/UserSettingsControllerTests.cs
+++ b/tests/Diariz.Api.Tests/UserSettingsControllerTests.cs
@@ -1,16 +1,21 @@
+using Diariz.Api.Configuration;
 using Diariz.Api.Contracts;
 using Diariz.Api.Controllers;
 using Diariz.Api.Tests.Infrastructure;
 using Diariz.Domain;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
 
 namespace Diariz.Api.Tests;
 
 public class UserSettingsControllerTests
 {
-    private static UserSettingsController Build(DiarizDbContext db, Guid userId) =>
-        new(db, new FakeApiKeyProtector()) { ControllerContext = Http.Context(userId) };
+    private static UserSettingsController Build(DiarizDbContext db, Guid userId, SummarizationOptions? server = null) =>
+        new(db, new FakeApiKeyProtector(), Options.Create(server ?? new SummarizationOptions()))
+        {
+            ControllerContext = Http.Context(userId)
+        };
 
     [Fact]
     public async Task Get_NoSettings_ReturnsEmpty()
@@ -83,6 +88,29 @@ public class UserSettingsControllerTests
         var dto = await Build(db, userId).Get();
         Assert.Null(dto.ApiBase);
         Assert.Null(dto.Model);
+    }
+
+    [Fact]
+    public async Task Get_ExposesServerDefaults_AsPlaceholders_WithoutTheServerKey()
+    {
+        using var db = TestDb.Create();
+        var server = new SummarizationOptions
+        {
+            ApiBase = "https://server/v1",
+            Model = "server-model",
+            ApiKey = "sk-server-secret",
+        };
+
+        var dto = await Build(db, Guid.NewGuid(), server).Get();
+
+        Assert.Equal("https://server/v1", dto.DefaultApiBase);
+        Assert.Equal("server-model", dto.DefaultModel);
+        Assert.True(dto.ServerHasApiKey);
+        // Server key must never be serialised to the client.
+        Assert.DoesNotContain("sk-server-secret", System.Text.Json.JsonSerializer.Serialize(dto));
+        // No per-user override set, so the user's own fields stay null.
+        Assert.Null(dto.ApiBase);
+        Assert.False(dto.HasApiKey);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Five focused UI improvements (with the small backend bits they need).

### 1. Full-width central panel
The selected-recording panel now uses all remaining width — dropped the `max-w-3xl` wrapper in `Workspace`.

### 2. Edit a transcription segment
Each segment row gets a kebab → **Edit** that opens a modal pre-filled with the current text. `SegmentDto` now carries the segment `id`, and a new `PUT /api/recordings/{id}/segments/{segmentId}` updates the text with an ownership check (segment → recording → user).

### 3. Settings show system-wide values as defaults
The settings `GET` now returns `DefaultApiBase`/`DefaultModel`/`ServerHasApiKey` (the server API key is **never** serialised). The modal shows these as **placeholders**, so the user can see what applies when a field is left blank — and a blank field is **not** persisted as their own override.

### 4. Stop password-manager autofill
The settings inputs were being autofilled as login username/password. Renamed them to non-login field names (`diariz-summary-endpoint/-model/-key`) with `autocomplete="off"` (and `new-password` on the key), and relabelled them "Summarisation endpoint/model/API key".

### 5. Resizable right (chat) panel
A drag handle on the chat panel's left edge resizes it (clamped 260–640px, persisted to localStorage). The left panel stays fixed.

## Testing
TDD throughout:
- **.NET unit** (71 passed / 1 pre-existing skip): segment-update endpoint (update, cross-user 404, wrong-recording 404), settings server-defaults (placeholders exposed, server key never returned), plus the `SegmentDto` id propagation.
- **.NET integration** (14 passed).
- **Web** (48 passed): Workspace drag-resize + persist, segment-edit modal saves via `updateSegment`, settings default-placeholder shown + blank-not-persisted. `npm run build` clean.
- **Live e2e** (rebuilt api+web): `PUT` segment returns 204 and the text updates with `id` present in the DTO; settings `GET` exposes the server defaults without the key.

Hard-refresh to pick up the new bundle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)