### PR TITLE
Auto-summarise (and auto-name) after transcription completes

### DIFF
--- a/src/Diariz.Api/Controllers/WorkerCallbackController.cs
+++ b/src/Diariz.Api/Controllers/WorkerCallbackController.cs
@@ -1,6 +1,7 @@
 using Diariz.Api.Configuration;
 using Diariz.Api.Contracts;
 using Diariz.Api.Hubs;
+using Diariz.Api.Services;
 using Diariz.Domain;
 using Diariz.Domain.Entities;
 using Microsoft.AspNetCore.Mvc;
@@ -20,12 +21,18 @@ public class WorkerCallbackController : ControllerBase
 {
     private readonly DiarizDbContext _db;
     private readonly IHubContext<TranscriptionHub> _hub;
+    private readonly IJobQueue _queue;
+    private readonly ISummarizationSettingsResolver _summarization;
     private readonly WorkerOptions _opts;
 
-    public WorkerCallbackController(DiarizDbContext db, IHubContext<TranscriptionHub> hub, IOptions<WorkerOptions> opts)
+    public WorkerCallbackController(
+        DiarizDbContext db, IHubContext<TranscriptionHub> hub, IJobQueue queue,
+        ISummarizationSettingsResolver summarization, IOptions<WorkerOptions> opts)
     {
         _db = db;
         _hub = hub;
+        _queue = queue;
+        _summarization = summarization;
         _opts = opts.Value;
     }
 
@@ -75,11 +82,21 @@ public class WorkerCallbackController : ControllerBase
             });
         }
 
-        transcription.Recording.Status = RecordingStatus.Transcribed;
         transcription.Recording.Error = null;  // clear any error from a prior failed attempt
+
+        // Continue the pipeline: when summarisation is configured for the owner, kick it off
+        // automatically (which also auto-names the recording when it has no name yet).
+        var cfg = await _summarization.ResolveAsync(transcription.Recording.UserId);
+        var autoSummarise = cfg.Enabled;
+        transcription.Recording.Status = autoSummarise ? RecordingStatus.Summarizing : RecordingStatus.Transcribed;
+
         await _db.SaveChangesAsync();
+
+        if (autoSummarise)
+            await _queue.EnqueueSummarizationAsync(new SummarizationJob(transcription.RecordingId, transcription.Id));
+
         await _hub.NotifyStatusAsync(transcription.Recording.UserId, transcription.RecordingId,
-            RecordingStatus.Transcribed.ToString());
+            transcription.Recording.Status.ToString());
         return Ok();
     }
 

--- a/src/Diariz.Api/Services/SummarizationPrompt.cs
+++ b/src/Diariz.Api/Services/SummarizationPrompt.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 using Diariz.Api.Contracts;
 
 namespace Diariz.Api.Services;
@@ -48,26 +49,48 @@ public static class SummarizationPrompt
 
         content = StripCodeFence(content);
 
-        try
+        // Content may be wrapped in prose or model-specific tokens (e.g. gpt-oss "harmony"
+        // markers like <|channel|>final<|constrain|>{...}); pull out the embedded JSON object.
+        var json = ExtractJsonObject(content);
+        if (json is not null)
         {
-            using var inner = JsonDocument.Parse(content);
-            var summary = inner.RootElement.TryGetProperty("summary", out var s)
-                ? s.GetString()?.Trim() ?? ""
-                : content;
-            string? name = null;
-            if (needName && inner.RootElement.TryGetProperty("name", out var n))
+            try
             {
-                var raw = n.GetString()?.Trim();
-                name = string.IsNullOrWhiteSpace(raw) ? null : raw;
+                using var inner = JsonDocument.Parse(json);
+                if (inner.RootElement.ValueKind == JsonValueKind.Object)
+                {
+                    var summary = inner.RootElement.TryGetProperty("summary", out var s)
+                        && s.ValueKind == JsonValueKind.String
+                            ? s.GetString()!.Trim()
+                            : StripModelTokens(content);
+                    string? name = null;
+                    if (needName && inner.RootElement.TryGetProperty("name", out var n)
+                        && n.ValueKind == JsonValueKind.String)
+                    {
+                        var raw = n.GetString()?.Trim();
+                        name = string.IsNullOrWhiteSpace(raw) ? null : raw;
+                    }
+                    return new SummaryResult(summary, name);
+                }
             }
-            return new SummaryResult(summary, name);
+            catch (JsonException) { /* fall through to the plain-text fallback */ }
         }
-        catch (JsonException)
-        {
-            // Model didn't return JSON — use the raw text as the summary.
-            return new SummaryResult(content, null);
-        }
+
+        // No usable JSON — return the text with any model tokens stripped.
+        return new SummaryResult(StripModelTokens(content), null);
     }
+
+    /// <summary>The substring from the first "{" to the last "}", or null if there's no object.</summary>
+    private static string? ExtractJsonObject(string s)
+    {
+        var start = s.IndexOf('{');
+        var end = s.LastIndexOf('}');
+        return start >= 0 && end > start ? s[start..(end + 1)] : null;
+    }
+
+    /// <summary>Strips model control tokens like &lt;|channel|&gt; so a non-JSON fallback reads cleanly.</summary>
+    private static string StripModelTokens(string s) =>
+        Regex.Replace(s, @"<\|[^|]*\|>", " ").Trim();
 
     private static string BuildTranscript(IReadOnlyList<SegmentDto> segments, int charBudget)
     {

--- a/tests/Diariz.Api.Tests/SummarizationPromptTests.cs
+++ b/tests/Diariz.Api.Tests/SummarizationPromptTests.cs
@@ -79,6 +79,40 @@ public class SummarizationPromptTests
     }
 
     [Fact]
+    public void ParseResponse_ExtractsJson_WrappedInModelTokens()
+    {
+        // gpt-oss "harmony" channel markers around the JSON object.
+        var json = ChatResponse("<|channel|>final <|constrain|>{\"summary\":\"All good.\",\"name\":\"Sync\"}");
+
+        var result = SummarizationPrompt.ParseResponse(json, needName: true);
+
+        Assert.Equal("All good.", result.Summary);
+        Assert.Equal("Sync", result.Name);
+    }
+
+    [Fact]
+    public void ParseResponse_ExtractsJson_WrappedInProse()
+    {
+        var json = ChatResponse("Sure! Here is the summary:\n{\"summary\":\"Done.\"}\nHope that helps.");
+
+        var result = SummarizationPrompt.ParseResponse(json, needName: false);
+
+        Assert.Equal("Done.", result.Summary);
+    }
+
+    [Fact]
+    public void ParseResponse_StripsModelTokens_InPlainTextFallback()
+    {
+        var json = ChatResponse("<|channel|>final<|message|>Just prose, no JSON here.");
+
+        var result = SummarizationPrompt.ParseResponse(json, needName: true);
+
+        Assert.DoesNotContain("<|", result.Summary);
+        Assert.Contains("Just prose", result.Summary);
+        Assert.Null(result.Name);
+    }
+
+    [Fact]
     public void ParseResponse_FallsBackToRawContent_OnMalformedJson()
     {
         var json = ChatResponse("Just a plain sentence, not JSON.");

--- a/tests/Diariz.Api.Tests/WorkerCallbackControllerTests.cs
+++ b/tests/Diariz.Api.Tests/WorkerCallbackControllerTests.cs
@@ -1,6 +1,7 @@
 using Diariz.Api.Configuration;
 using Diariz.Api.Contracts;
 using Diariz.Api.Controllers;
+using Diariz.Api.Services;
 using Diariz.Api.Tests.Infrastructure;
 using Diariz.Domain;
 using Diariz.Domain.Entities;
@@ -14,15 +15,29 @@ public class WorkerCallbackControllerTests
 {
     private const string Secret = "shared-secret";
 
+    // Default: summarisation NOT configured, so Result leaves the recording at Transcribed.
     private static (WorkerCallbackController controller, DiarizDbContext db, FakeHubContext hub) Build(string presentedSecret)
+    {
+        var (controller, db, hub, _) = BuildEx(presentedSecret, summarizationEnabled: false);
+        return (controller, db, hub);
+    }
+
+    private static (WorkerCallbackController controller, DiarizDbContext db, FakeHubContext hub, FakeJobQueue queue)
+        BuildEx(string presentedSecret, bool summarizationEnabled)
     {
         var db = TestDb.Create();
         var hub = new FakeHubContext();
-        var controller = new WorkerCallbackController(db, hub, Options.Create(new WorkerOptions { CallbackSecret = Secret }))
+        var queue = new FakeJobQueue();
+        var resolver = new SummarizationSettingsResolver(
+            db,
+            Options.Create(new SummarizationOptions { ApiBase = summarizationEnabled ? "http://llm.test/v1" : "" }),
+            new FakeApiKeyProtector());
+        var controller = new WorkerCallbackController(
+            db, hub, queue, resolver, Options.Create(new WorkerOptions { CallbackSecret = Secret }))
         {
             ControllerContext = Http.Context(headers: ("X-Worker-Secret", presentedSecret))
         };
-        return (controller, db, hub);
+        return (controller, db, hub, queue);
     }
 
     private static async Task<(Guid recordingId, Guid transcriptionId)> SeedQueuedRecording(DiarizDbContext db, Guid userId)
@@ -116,6 +131,38 @@ public class WorkerCallbackControllerTests
 
         var seg = await db.Segments.SingleAsync(s => s.TranscriptionId == transcriptionId);
         Assert.Equal("UNKNOWN", seg.SpeakerLabel);
+    }
+
+    [Fact]
+    public async Task Result_WhenSummarisationConfigured_MarksSummarizing_AndEnqueuesJob()
+    {
+        var (controller, db, hub, queue) = BuildEx(Secret, summarizationEnabled: true);
+        var (recordingId, transcriptionId) = await SeedQueuedRecording(db, Guid.NewGuid());
+
+        await controller.Result(new TranscriptionResult(transcriptionId, "en",
+            [new SegmentResult("SPEAKER_00", 0, 1000, "Hello")]));
+
+        // Transcript still persisted, but the pipeline auto-continues into summarisation.
+        var rec = await db.Recordings.FindAsync(recordingId);
+        Assert.Equal(RecordingStatus.Summarizing, rec!.Status);
+        var job = Assert.Single(queue.SummarizationEnqueued);
+        Assert.Equal(recordingId, job.RecordingId);
+        Assert.Equal(transcriptionId, job.TranscriptionId);
+        // The owner is notified with the new status.
+        Assert.Contains(hub.Sent, m => m.Method == "RecordingStatusChanged");
+    }
+
+    [Fact]
+    public async Task Result_WhenSummarisationNotConfigured_StaysTranscribed_AndDoesNotEnqueue()
+    {
+        var (controller, db, _, queue) = BuildEx(Secret, summarizationEnabled: false);
+        var (recordingId, transcriptionId) = await SeedQueuedRecording(db, Guid.NewGuid());
+
+        await controller.Result(new TranscriptionResult(transcriptionId, "en",
+            [new SegmentResult("SPEAKER_00", 0, 1000, "Hello")]));
+
+        Assert.Equal(RecordingStatus.Transcribed, (await db.Recordings.FindAsync(recordingId))!.Status);
+        Assert.Empty(queue.SummarizationEnqueued);
     }
 
     [Fact]


### PR DESCRIPTION
## Summary

Extends the transcription pipeline to **automatically summarise** a recording once transcription finishes — including **auto-naming** it — instead of requiring a manual "Summarise" click.

- When the worker posts a transcription result (`WorkerCallbackController.Result`), the controller resolves the recording owner's effective summarisation config. If it's enabled (their per-user settings, else the server default), it marks the recording `Summarizing` and enqueues a summarisation job; the existing summariser then writes the `Summary` and **auto-names** the recording when it has no name yet.
- If summarisation isn't configured, the recording stays `Transcribed` exactly as before. Applies to both first uploads and re-transcribes. The transcript is still persisted on the same save, so the UI shows it immediately with a "Summarising…" state and updates live via SignalR.

### Parsing hardening (so it actually works with real models)
`gpt-oss`-style models return the JSON wrapped in "harmony" channel tokens (e.g. `<|channel|>final <|constrain|>{…}`). The response parser now extracts the embedded JSON object (first `{` → last `}`) before parsing — so prose- or token-wrapped output still yields a clean summary/name — and strips model tokens from any plain-text fallback.

## Testing
TDD:
- **WorkerCallback**: auto-enqueues `Summarizing` + a job when configured; stays `Transcribed` with no enqueue when not.
- **Parser**: token-wrapped JSON, prose-wrapped JSON, and token-stripped plain-text fallback.
- Suites green: API unit **88**/1-skip, integration **14**. No frontend changes (the UI already follows the `Summarizing → Summarized` SignalR flow).

**Live e2e** (rebuilt api, real LLM endpoint): re-transcribed a recording with its name cleared → it auto-progressed `Queued → Summarizing → Summarized`, produced a clean summary (no leftover model tokens), and auto-named itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)