### PR TITLE
Chat persists across collapse + Clear button; quieter list status pills

### DIFF
--- a/apps/web/src/components/ChatPanel.test.tsx
+++ b/apps/web/src/components/ChatPanel.test.tsx
@@ -144,6 +144,16 @@ describe("ChatPanel", () => {
     await waitFor(() => expect(api.deleteChatConversation).toHaveBeenCalledWith("conv-1"));
   });
 
+  it("clears the conversation thread with the Clear button", async () => {
+    renderPanel("/recordings/rec-1");
+    await ask("Tell me something");
+    await waitFor(() => expect(screen.getByText("world", { exact: false })).toBeTruthy());
+
+    await act(async () => fireEvent.click(screen.getByRole("button", { name: /clear conversation/i })));
+
+    expect(screen.queryByText("world", { exact: false })).toBeNull();
+  });
+
   it("attaches a file and includes its text in the request", async () => {
     mock(api.uploadChatAttachment).mockResolvedValue({ name: "spec.pdf", text: "blue widget", chars: 11 });
     const { container } = renderPanel("/recordings/rec-1");

--- a/apps/web/src/components/ChatPanel.tsx
+++ b/apps/web/src/components/ChatPanel.tsx
@@ -125,7 +125,8 @@ export default function ChatPanel() {
     abortRef.current?.abort();
   }
 
-  function newChat() {
+  /// Clear the current conversation thread (stops any stream and resets to a blank chat).
+  function clearThread() {
     stop();
     setMessages([]);
     setUsage(null);
@@ -214,7 +215,7 @@ export default function ChatPanel() {
     if (!openedId) return;
     try {
       await api.deleteChatConversation(openedId);
-      newChat();
+      clearThread();
       setSavedList((prev) => prev.filter((c) => c.id !== openedId));
     } catch (e) {
       setError(apiErrorMessage(e));
@@ -259,8 +260,8 @@ export default function ChatPanel() {
             </div>
           )}
         </div>
-        <IconButton label="New chat" onClick={newChat}>
-          <PlusIcon />
+        <IconButton label="Clear conversation" onClick={clearThread} disabled={!started}>
+          <EraserIcon />
         </IconButton>
         <IconButton label="Save conversation" onClick={saveConversation} disabled={!started || streaming || saving}>
           <SaveIcon />
@@ -463,9 +464,9 @@ const BookmarkIcon = () => (
     <path d="M19 21l-7-5-7 5V5a2 2 0 0 1 2-2h10a2 2 0 0 1 2 2z" />
   </svg>
 );
-const PlusIcon = () => (
+const EraserIcon = () => (
   <svg {...iconProps}>
-    <path d="M12 5v14M5 12h14" />
+    <path d="M7 21h10M4 13l6 6 9-9a2 2 0 0 0 0-3l-3-3a2 2 0 0 0-3 0L4 13z" />
   </svg>
 );
 const SaveIcon = () => (

--- a/apps/web/src/components/RecordingsPanel.test.tsx
+++ b/apps/web/src/components/RecordingsPanel.test.tsx
@@ -152,6 +152,20 @@ describe("RecordingsPanel", () => {
     expect(screen.queryByRole("menuitem", { name: /\.srt/i })).toBeNull();
   });
 
+  it("hides the status pill for settled states but shows in-flight ones", async () => {
+    (api.listRecordings as ReturnType<typeof vi.fn>).mockResolvedValue([
+      { ...rec, id: "done", name: "Finished", status: "Summarized" },
+      { ...rec, id: "busy", name: "Working", status: "Summarizing" },
+      { ...rec, id: "bad", name: "Broken", status: "Failed" },
+    ]);
+    renderList();
+    await screen.findByText("Finished");
+
+    expect(screen.queryByText("Summarized")).toBeNull(); // settled → no pill
+    expect(screen.getByText("Summarizing")).toBeTruthy(); // in-flight → pill shown
+    expect(screen.getByText("Failed")).toBeTruthy(); // failures still surface
+  });
+
   it("toggles Select mode to reveal selection checkboxes", async () => {
     renderList();
     await screen.findByText("Weekly Standup");

--- a/apps/web/src/components/RecordingsPanel.tsx
+++ b/apps/web/src/components/RecordingsPanel.tsx
@@ -28,6 +28,12 @@ export function hasTranscript(status: RecordingStatus): boolean {
   return status === "Transcribed" || status === "Summarizing" || status === "Summarized";
 }
 
+/// Show the status pill only while the pipeline is moving. The settled success states
+/// (Transcribed/Summarized) repeat on every row and truncate the name, so they're hidden.
+export function showStatusBadge(status: RecordingStatus): boolean {
+  return status !== "Transcribed" && status !== "Summarized";
+}
+
 interface Group {
   id: string | null; // section id, or null for ungrouped
   name: string;
@@ -381,9 +387,11 @@ function RecordingRow({
             </div>
           </NavLink>
         )}
-        <span className={`shrink-0 rounded px-1.5 py-0.5 text-[10px] ${statusColor[r.status]}`}>
-          {r.status}
-        </span>
+        {showStatusBadge(r.status) && (
+          <span className={`shrink-0 rounded px-1.5 py-0.5 text-[10px] ${statusColor[r.status]}`}>
+            {r.status}
+          </span>
+        )}
         <KebabMenu actions={actions} />
       </div>
       {error && <p className="mt-1 text-xs text-red-600 dark:text-red-400">{error}</p>}

--- a/apps/web/src/components/Workspace.test.tsx
+++ b/apps/web/src/components/Workspace.test.tsx
@@ -24,11 +24,22 @@ function renderWorkspace(initial = "/") {
 describe("Workspace", () => {
   beforeEach(() => localStorage.clear());
 
-  it("shows the list by default and the chat panel starts collapsed", () => {
+  it("shows the list by default and the chat panel starts collapsed (but stays mounted)", () => {
     renderWorkspace();
     expect(screen.getByText("LIST")).toBeTruthy();
-    expect(screen.queryByText("CHAT")).toBeNull();
     expect(screen.getByRole("button", { name: /expand chat panel/i })).toBeTruthy();
+    // Mounted for state preservation, but inside the hidden container while collapsed.
+    expect(screen.getByText("CHAT").closest(".hidden")).toBeTruthy();
+  });
+
+  it("keeps the chat panel mounted across collapse/expand (preserves its state)", () => {
+    renderWorkspace();
+    // Expand → not hidden; collapse → hidden; the element is never removed from the DOM.
+    fireEvent.click(screen.getByRole("button", { name: /expand chat panel/i }));
+    expect(screen.getByText("CHAT").closest(".hidden")).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: /collapse chat panel/i }));
+    expect(screen.getByText("CHAT")).toBeTruthy();
+    expect(screen.getByText("CHAT").closest(".hidden")).toBeTruthy();
   });
 
   it("collapses the left panel and persists the choice", () => {
@@ -42,7 +53,7 @@ describe("Workspace", () => {
   it("expands the chat panel when requested", () => {
     renderWorkspace();
     fireEvent.click(screen.getByRole("button", { name: /expand chat panel/i }));
-    expect(screen.getByText("CHAT")).toBeTruthy();
+    expect(screen.getByText("CHAT").closest(".hidden")).toBeNull();
   });
 
   it("renders the routed detail in the middle panel", () => {

--- a/apps/web/src/components/Workspace.tsx
+++ b/apps/web/src/components/Workspace.tsx
@@ -70,28 +70,27 @@ export default function Workspace() {
         </div>
       </main>
 
-      {rightOpen ? (
-        <div className="flex shrink-0">
-          <div
-            role="separator"
-            aria-orientation="vertical"
-            aria-label="Resize chat panel"
-            onMouseDown={startResize}
-            className="w-1 cursor-col-resize bg-transparent transition-colors hover:bg-blue-400 dark:hover:bg-blue-600"
-          />
-          <aside
-            style={{ width: rightWidth }}
-            className="flex shrink-0 flex-col border-l bg-white dark:border-gray-700 dark:bg-gray-900"
-          >
-            <PanelHeader title="Chat" onCollapse={() => setRightOpen(false)} chevron="▶" />
-            <div className="min-h-0 flex-1 overflow-y-auto">
-              <ChatPanel />
-            </div>
-          </aside>
-        </div>
-      ) : (
-        <CollapsedRail label="Chat" onExpand={() => setRightOpen(true)} chevron="◀" />
-      )}
+      {/* The chat panel stays mounted even when collapsed (hidden via CSS) so its conversation
+          state survives collapse/expand. The rail is shown alongside when collapsed. */}
+      <div className={rightOpen ? "flex shrink-0" : "hidden"}>
+        <div
+          role="separator"
+          aria-orientation="vertical"
+          aria-label="Resize chat panel"
+          onMouseDown={startResize}
+          className="w-1 cursor-col-resize bg-transparent transition-colors hover:bg-blue-400 dark:hover:bg-blue-600"
+        />
+        <aside
+          style={{ width: rightWidth }}
+          className="flex shrink-0 flex-col border-l bg-white dark:border-gray-700 dark:bg-gray-900"
+        >
+          <PanelHeader title="Chat" onCollapse={() => setRightOpen(false)} chevron="▶" />
+          <div className="min-h-0 flex-1 overflow-y-auto">
+            <ChatPanel />
+          </div>
+        </aside>
+      </div>
+      {!rightOpen && <CollapsedRail label="Chat" onExpand={() => setRightOpen(true)} chevron="◀" />}
     </div>
     </SelectionProvider>
   );


### PR DESCRIPTION
Three UX refinements requested after the chat feature landed.

## Chat panel
- **Persists across collapse/expand.** The panel is now kept mounted (hidden via CSS) when the right panel is collapsed, instead of being unmounted. Your conversation, draft input, attachment and context selection survive collapsing and re-expanding.
- **Clear button.** The toolbar's "New chat" (+) is replaced with an explicit **Clear conversation** (eraser) button that empties the current thread; it's disabled when the thread is already empty.

## Recording list
- The status pill now shows **only while the pipeline is moving** (Uploaded / Queued / Transcribing / Summarizing) and for **Failed**. The settled success states (**Transcribed / Summarized**) are hidden — they repeated on every row and truncated the recording name. The transient transitions during processing are still shown, as they're useful.

## Testing
Web suite **85 passing** (new coverage: chat stays mounted across collapse/expand, Clear empties the thread, and the status pill shows in-flight/Failed but hides settled states). Build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)