### PR TITLE
docs(desktop): temporary release-tagging reminder

### DIFF
--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -64,9 +64,28 @@ npm run dist       # builds release/Diariz Setup <version>.exe (NSIS), no publis
 
 ## Release
 
+> **📌 Release reminder — temporary, remove once it's muscle memory.**
+> A version bump alone does **not** publish an installer — you must push a matching **tag**. Whenever the
+> desktop app changes and you want a downloadable build:
+>
+> 1. Land the change on `main` first, **including the version bump** (`version.json` + the web/desktop
+>    `package.json` + the API `<Version>`), exactly like any other PR — then merge it.
+> 2. From an up-to-date `main`, tag that commit and push the tag. **The tag must equal `version.json`,
+>    prefixed with `v`:**
+>    ```bash
+>    git checkout main && git pull
+>    git tag v0.12.3            # ← use the version from version.json
+>    git push origin v0.12.3    # this push is what triggers the release build
+>    ```
+> 3. The push runs `desktop-release.yml` → builds and publishes `Diariz-Setup-<version>.exe` (+ `latest.yml`)
+>    straight to GitHub Releases (no draft step; `releaseType: "release"`).
+>
+> If a tagged build fails: fix it, **bump to a new version**, and tag *that* — never reuse a tag. Delete a
+> bad tag with `git push origin :refs/tags/v0.12.3 && git tag -d v0.12.3`.
+
 Pushing a `v*` tag (matching `package.json` / `version.json`) runs `.github/workflows/desktop-release.yml`
 on the self-hosted Windows runner, which builds the installer and publishes it to this repo's **GitHub
-Releases** (+ `latest.yml` for auto-update in a later phase).
+Releases** (+ `latest.yml`, which the app's auto-updater reads).
 
 **Self-hosted feed** (no GitHub dependency, e.g. for a private fork): build with
 `DIARIZ_PUBLISH=generic DIARIZ_UPDATE_URL=https://your-server/updates/ npm run dist` and upload


### PR DESCRIPTION
Adds a clearly-marked **temporary reminder** to the top of `apps/desktop/README.md`'s Release section, per request — to be removed once tagging is muscle memory.

It captures the bit that's easy to forget: **a version bump alone doesn't publish an installer — you must push a matching `v<version>` tag**, which is what triggers `desktop-release.yml`. Includes the exact `git tag` / `git push origin <tag>` commands and the "bump again, don't reuse a tag" rule for failed builds. Also refreshed a stale "auto-update in a later phase" line (auto-update shipped in 0.12.0).

**Docs-only, intentionally no version bump / release-notes entry** — it's an internal developer reminder, not a shipped user-facing change, and adding (then later removing) it would otherwise spawn two pointless entries in the in-app changelog. Shout if you'd rather I follow the strict per-PR bump instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)