### PR TITLE
docs(CLAUDE): require PRs to state desktop-release vs server-redeploy

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,6 +117,14 @@ is **Major.Minor.Build** (currently `0.x`).
   change, or a shipped roadmap milestone — update the README's **Features**, **Architecture**, and
   **Roadmap** sections and its version line in the same PR (it mirrors the `CAPABILITIES`/release-notes
   edits above).
+- **State the deployment surface in every PR.** When opening a PR, say whether shipping it needs a
+  **desktop release** (a new installer, cut by pushing a `v*` tag) or just a **server redeploy**. The
+  desktop app is a thin shell that loads the web app from the server origin, so it only needs a new release
+  when the PR touches the **desktop shell** — `apps/desktop/src/**`, `electron-builder.config.js`, or desktop
+  dependencies. **Web (`apps/web`) and API (`src/Diariz.Api`) changes ship by redeploying the server** and
+  are picked up by installed desktop apps automatically. A lockstep version bump to `apps/desktop/package.json`
+  alone does **not** require a desktop release (desktop version numbers may skip). Docs/CI-only PRs need
+  neither — say so.
 
 The About box (account menu → About) and the `/release-notes` page render from this data.
 


### PR DESCRIPTION
Adds a rule to CLAUDE.md's *Versioning & release notes* section: **every PR must state whether shipping it needs a desktop release (a `v*` tag → new installer) or just a server redeploy.**

Rationale captured in the rule: the desktop app is a thin shell that loads the web app from the server origin, so it only needs a new release when the PR touches the **desktop shell** (`apps/desktop/src/**`, `electron-builder.config.js`, or desktop deps). Web (`apps/web`) and API (`src/Diariz.Api`) changes ship by redeploying the server and are picked up by installed desktop apps automatically. A lockstep version bump to `apps/desktop/package.json` alone doesn't require a desktop release.

**Deployment surface for this PR: neither — docs only** (CLAUDE.md guidance). No version bump or release-notes entry; nothing to deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)