### PR TITLE
chore(worker): pip cache mount + .dockerignore for fast rebuilds

### DIFF
--- a/src/Diariz.Worker/.dockerignore
+++ b/src/Diariz.Worker/.dockerignore
@@ -1,0 +1,12 @@
+# Keep the build context (and the final COPY layer) free of local dev junk so it
+# doesn't bust the cache or bloat the image. Tests run on the host/CI, not in the image.
+__pycache__/
+*.pyc
+.pytest_cache/
+.venv/
+venv/
+env/
+tests/
+requirements-test.txt
+*.md
+.git/

--- a/src/Diariz.Worker/Dockerfile
+++ b/src/Diariz.Worker/Dockerfile
@@ -1,3 +1,4 @@
+# syntax=docker/dockerfile:1
 # GPU-enabled transcription worker (WhisperX + pyannote).
 # Requires the NVIDIA Container Toolkit on the host to expose the GPU.
 #
@@ -14,16 +15,21 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 WORKDIR /app
 
 # CUDA-enabled torch first (cu128 wheels include sm_120 kernels), then the rest.
-RUN pip3 install --no-cache-dir torch==2.7.1 torchaudio==2.7.1 \
+# The pip cache mount keeps downloaded wheels on the BuildKit cache, so a rebuild of this
+# (multi-GB) layer reinstalls from cache instead of re-downloading ~10 GB.
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip3 install torch==2.7.1 torchaudio==2.7.1 \
     --index-url https://download.pytorch.org/whl/cu128
 
 COPY requirements.txt ./
-RUN pip3 install --no-cache-dir -r requirements.txt
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip3 install -r requirements.txt
 
 # whisperx 3.3.1 conservatively pins ctranslate2<4.5.0, but Blackwell (sm_120)
 # support only landed in ctranslate2 4.6.3 (CUDA 12.8; INT8 disabled on sm_120 so
 # the worker's float16 compute_type is the supported path). Force past the cap.
-RUN pip3 install --no-cache-dir --no-deps --force-reinstall ctranslate2==4.6.3
+RUN --mount=type=cache,target=/root/.cache/pip \
+    pip3 install --no-deps --force-reinstall ctranslate2==4.6.3
 
 COPY . ./
 


### PR DESCRIPTION
Fixes the worker re-downloading its ~10 GB torch/CUDA stack on every rebuild.

**Diagnosis (from your build log):** api + web were fully `CACHED`; only the worker rebuilt — from `apt-get` onward, re-downloading torch. Its multi-GB layers were evicted from the build cache, and because every pip line used `--no-cache-dir`, a rebuilt layer had **no wheels to reuse** → full re-download.

**Changes (build-time only — image contents unchanged):**
- BuildKit **pip cache mount** (`--mount=type=cache,target=/root/.cache/pip`) on the three pip installs; dropped `--no-cache-dir`. A rebuilt layer now reinstalls from cached wheels instead of re-fetching. The cache lives **outside** the image, so the produced image is the same (or smaller).
- `# syntax=docker/dockerfile:1` to guarantee the cache-mount syntax.
- A worker **`.dockerignore`** (`__pycache__`, `tests/`, `.venv`, `*.md`) so the source `COPY` layer doesn't bust on local junk.

> Note: the **real** fix for "evicted every time" is giving Docker more disk so the cache isn't GC'd (instructions provided separately). This change makes a rebuild cheap *even if* the cache is evicted. Base image left unpinned (not the cause; pinning would freeze CUDA/security updates).

**No version bump** — build infrastructure, no runtime/user-facing or image-content change (consistent with prior infra/docs PRs).
**Deployment surface:** none code-wise; adopt by rebuilding the worker image (`docker compose build worker`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)