### PR TITLE
Sync API csproj version to 0.68.0

### DIFF
--- a/src/Diariz.Api/Diariz.Api.csproj
+++ b/src/Diariz.Api/Diariz.Api.csproj
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <!-- App version — keep in sync with /version.json (see CLAUDE.md versioning rule). -->
-    <Version>0.67.1</Version>
+    <Version>0.68.0</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Corrects a mirror drift from #156: the API project's `<Version>` was accidentally left out of that commit, so it read **0.67.1** while `version.json`, `apps/web`/`apps/desktop` `package.json`, and `releases.ts` were all **0.68.0** — meaning `GET /health` reported the stale number.

This brings `src/Diariz.Api/Diariz.Api.csproj` back into lockstep. **No functional change; no new release entry** (0.68.0 already ships in `releases.ts`).

Deployment surface: server redeploy (API) to correct the reported version. No desktop release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)