### PR TITLE
ci: build the web app in CI, not just test it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,13 @@ jobs:
       - name: Install
         working-directory: apps/web
         run: npm ci
+      # `npm run build` is `tsc && vite build`, so this is the only gate covering two things
+      # vitest never touches: the TypeScript typecheck (tests are excluded from the build's tsc via
+      # tsconfig.json) and the production Vite/PostCSS/Tailwind pipeline. Runs before the tests so a
+      # type error or a broken build dependency fails in seconds rather than after the full suite.
+      - name: Build
+        working-directory: apps/web
+        run: npm run build
       - name: Test
         working-directory: apps/web
         run: npm test


### PR DESCRIPTION
## The gap

The `Web (vitest)` job ran `npm ci` + `npm test` and **never built**. Since `npm test` is `vitest run` (no typechecking) and tests are excluded from the build's `tsc` via `tsconfig.json`, two things had **zero** CI coverage:

- the **TypeScript typecheck** (`npm run build` is `tsc && vite build`)
- the **production Vite / PostCSS / Tailwind pipeline**

This surfaced while reviewing Dependabot #354 (postcss 8.5.22 -> 8.5.23). All 15 checks went green, but nothing in CI had exercised the build path that upgrade affects - postcss only runs during `vite build`. A build-breaking dependency bump would have merged clean. I had to check out that PR and build it by hand to review it.

## The change

One step added to the existing `web` job, reusing its `npm ci`:

```yaml
- name: Build
  working-directory: apps/web
  run: npm run build
```

Placed **before** the tests so a type error or broken build dependency fails in seconds rather than after the full suite. No new job, so no extra runner minutes beyond the build itself (~30s locally; the repo is public, so hosted runners are free and unlimited anyway).

## Release checklist

**Docs/CI-only PR** - per CLAUDE.md this skips items 1-3 (no version bump, no `RELEASES` entry, no `CAPABILITIES` change): nothing user-facing changes and the app version is untouched. Items 4-7 need no edit either - no feature, architecture, dependency, endpoint or schema change, so the README, `docs/features.md`, `Overall_Synopsis_of_Platform.md` and `Data_Schema.md` all remain accurate as they stand.

## Deployment surface

**Neither a desktop release nor a server redeploy.** CI-only - nothing ships.

## Known follow-on

The same gap exists for `apps/desktop` and the n8n community node, which are also tested but not built in CI. Out of scope here; worth a look separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)