### PR TITLE
docs: observability design and phase 1 + 2 implementation plans

### DIFF
--- a/docs/superpowers/plans/2026-07-31-observability-phase1-worker-api.md
+++ b/docs/superpowers/plans/2026-07-31-observability-phase1-worker-api.md
@@ -31,7 +31,9 @@
 | 3 | Tasks 6-8 | 0.174.3 | 1c - API |
 | - | Task 9 | none | 1d - prod rollout (operational, no code) |
 
-**Getting the `pr:` number right:** `RELEASES[0].pr` must be the real PR number, and it is needed *before* `gh pr create` has told you what it is. Do not guess "last + 1" - Dependabot PRs and issues share the sequence. Run `gh pr list --state all --limit 1` to see the highest number actually used, then use the next one, and correct it if `gh pr create` returns something different.
+**Getting the `pr:` number right:** `RELEASES[0].pr` must be the real PR number, and it is needed *before* `gh pr create` has told you what it is. Do not guess "last + 1" blindly - Dependabot PRs and issues share the sequence. Run `gh pr list --state all --limit 1` to see the highest number actually used, then use the next one, and correct it if `gh pr create` returns something different.
+
+The design/plan PR took **#389**, so the expected numbers are **390** (PR 1), **391** (PR 2) and **392** (PR 3). Re-check before each one - anything else merged in between shifts them.
 
 ---
 
@@ -274,7 +276,7 @@ Add to the top of `RELEASES` in `apps/web/src/lib/releases.ts` (get the real PR 
 {
   version: "0.174.1",
   date: "2026-07-31",
-  pr: 389,
+  pr: 390,
   headline: "Optional self-hosted error tracking",
   summary:
     "Adds an optional Docker Compose overlay for GlitchTip, a self-hosted error-tracking and " +
@@ -916,7 +918,7 @@ Same five files as Task 1 Step 7. Add to the top of `RELEASES`:
 {
   version: "0.174.2",
   date: "2026-07-31",
-  pr: 390,
+  pr: 391,
   headline: "Transcription worker reports failures and stage timings",
   summary:
     "When a GlitchTip DSN is configured, the transcription worker now reports unhandled failures " +
@@ -1305,7 +1307,7 @@ Record in `docs/Overall_Synopsis_of_Platform.md` that the API optionally reports
 {
   version: "0.174.3",
   date: "2026-07-31",
-  pr: 391,
+  pr: 392,
   headline: "API reports errors and endpoint timings",
   summary:
     "When a GlitchTip DSN is configured, the API now reports unhandled exceptions and records how " +

--- a/docs/superpowers/plans/2026-07-31-observability-phase1-worker-api.md
+++ b/docs/superpowers/plans/2026-07-31-observability-phase1-worker-api.md
@@ -1,0 +1,1398 @@
+# Observability Phase 1 (worker + API) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Stand up a self-hosted GlitchTip instance on the dev box and report unhandled exceptions plus stage/endpoint timings from the Python worker and the .NET API to it.
+
+**Architecture:** GlitchTip (MIT, Sentry wire-compatible) runs as an optional Docker Compose overlay with its own Postgres, its own MinIO bucket, and a shared Redis on DB index 1. The worker and API use the official Sentry SDKs. A single module per runtime (`telemetry.py`, `SentryScrubber.cs`) owns all SDK knowledge so the rest of the code stays SDK-agnostic and testable without the SDK installed.
+
+**Tech Stack:** GlitchTip 6.x, `sentry-sdk` (Python 2.x line), `Sentry.AspNetCore` (NuGet), Docker Compose, nginx.
+
+**Design spec:** `docs/superpowers/specs/2026-07-31-observability-glitchtip-design.md`
+
+## Global Constraints
+
+- **Off by default.** Every integration is disabled when its DSN is empty - no SDK init, no network call. Mirrors the existing `Summarization__ApiBase` / `Dictation__ApiBase` convention.
+- **`SendDefaultPii = false` / `send_default_pii=False`** on every SDK, always.
+- **No transcript, summary, minutes or note content may ever leave the process.** Ids only.
+- **TDD is required.** Write the failing test, run it, watch it fail, then implement. Task 1 is pure configuration and is the documented exception - it needs a human's sign-off instead.
+- **No em dashes or en dashes** (`-` only) in release notes and any user-facing copy.
+- **Every PR ships exactly one release:** bump `version.json` **and all four mirrors**, and add one `RELEASES[0]` entry. Current version at plan time: **0.174.0**.
+- **Never commit or push to `main`.** Branch, push, open a PR.
+- **Deployment surface for every PR in this plan: server redeploy, no desktop release.** State this in each PR description.
+- **GlitchTip cold storage uses its own MinIO bucket, never a prefix inside `recordings`.** Platform restore wipes the recordings bucket.
+
+## PR grouping
+
+| PR | Tasks | Version | Sub-phase |
+| --- | --- | --- | --- |
+| 1 | Task 1 | 0.174.1 | 1a - infrastructure on dev |
+| 2 | Tasks 2-5 | 0.174.2 | 1b - Python worker |
+| 3 | Tasks 6-8 | 0.174.3 | 1c - API |
+| - | Task 9 | none | 1d - prod rollout (operational, no code) |
+
+**Getting the `pr:` number right:** `RELEASES[0].pr` must be the real PR number, and it is needed *before* `gh pr create` has told you what it is. Do not guess "last + 1" - Dependabot PRs and issues share the sequence. Run `gh pr list --state all --limit 1` to see the highest number actually used, then use the next one, and correct it if `gh pr create` returns something different.
+
+---
+
+### Task 1: GlitchTip infrastructure overlay (sub-phase 1a, dev only)
+
+Pure configuration and documentation. **No TDD** - this is the CLAUDE.md "pure config" exception and needs a human's sign-off that the stack came up correctly, per the verification steps below.
+
+**Files:**
+- Create: `deploy/docker-compose.observability.yml`
+- Modify: `deploy/.env.example` (append the observability block)
+- Modify: `docs/Overall_Synopsis_of_Platform.md` (new optional component)
+- Modify: `version.json`, `apps/web/package.json`, `apps/desktop/package.json`, `src/Diariz.Api/Diariz.Api.csproj`, `integrations/n8n-nodes-diariz/package.json`
+- Modify: `apps/web/src/lib/releases.ts`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: two DSNs (worker + API), obtained from the GlitchTip UI and pasted into `deploy/.env` on the dev box. Consumed by Tasks 5 and 8 as `SENTRY_DSN` and `Sentry__Dsn`.
+
+- [ ] **Step 1: Create the compose overlay**
+
+Create `deploy/docker-compose.observability.yml`:
+
+```yaml
+# Optional observability overlay: self-hosted GlitchTip (error tracking + transaction timings).
+#
+# Opt-in, and deliberately a separate file so the core stack is unchanged for anyone who does not
+# want it:
+#   docker compose -f docker-compose.yml -f docker-compose.observability.yml up -d
+#
+# GlitchTip gets its OWN Postgres (not a second database inside the app's pgvector container):
+#   - the platform backup/restore operates on the app database; co-locating an observability tool's
+#     tables entangles two things with different retention and recovery semantics,
+#   - the postgres image only auto-creates POSTGRES_DB, and a second-database init script only runs
+#     on a FRESH volume - on the existing dev/prod boxes it would silently not run,
+#   - GlitchTip needs pg14+ while the app is pinned to 16 for pgvector; decoupling stops GlitchTip's
+#     upgrade cycle blocking the app's.
+#
+# It DOES share the app's Redis, on DB index 1. VALKEY_URL is optional for GlitchTip and only affects
+# caching and task-queue speed, so the blast radius is small and it saves a container.
+name: diariz
+
+services:
+  glitchtip-postgres:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: glitchtip
+      POSTGRES_USER: glitchtip
+      POSTGRES_PASSWORD: ${GLITCHTIP_POSTGRES_PASSWORD:-glitchtip}
+    volumes:
+      - glitchtipdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U glitchtip"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+  glitchtip:
+    image: glitchtip/glitchtip:v6.2
+    restart: unless-stopped
+    depends_on:
+      glitchtip-postgres: { condition: service_healthy }
+      redis: { condition: service_healthy }
+    environment:
+      DATABASE_URL: "postgres://glitchtip:${GLITCHTIP_POSTGRES_PASSWORD:-glitchtip}@glitchtip-postgres:5432/glitchtip"
+      # DB index 1 - the app's queues live on index 0 and must not be disturbed.
+      VALKEY_URL: "redis://redis:6379/1"
+      SECRET_KEY: ${GLITCHTIP_SECRET_KEY}
+      # MUST include the scheme. Django derives its trusted CSRF origins from this, and a mismatch
+      # presents as "wrong password" on every login attempt rather than anything mentioning CSRF.
+      GLITCHTIP_DOMAIN: ${GLITCHTIP_DOMAIN}
+      DEFAULT_FROM_EMAIL: ${GLITCHTIP_FROM_EMAIL}
+      EMAIL_URL: ${GLITCHTIP_EMAIL_URL}
+      # Internal tool on a public subdomain: no open registration, no new orgs.
+      ENABLE_USER_REGISTRATION: "false"
+      ENABLE_ORGANIZATION_CREATION: "false"
+      # Spans (as opposed to bare transactions) require DuckDB. It runs inside the existing Python
+      # process writing Parquet, so this costs ~128 MB of RAM and no extra container.
+      GLITCHTIP_ENABLE_DUCKDB: "true"
+      GLITCHTIP_COLD_STORAGE_BUCKET: ${GLITCHTIP_COLD_STORAGE_BUCKET:-glitchtip}
+      AWS_S3_ENDPOINT_URL: "http://minio:9000"
+      AWS_ACCESS_KEY_ID: ${GLITCHTIP_MINIO_ACCESS_KEY}
+      AWS_SECRET_ACCESS_KEY: ${GLITCHTIP_MINIO_SECRET_KEY}
+    ports:
+      # Published for the OUTER reverse proxy only. Bind to localhost so it is not LAN-reachable:
+      # Docker publishes to 0.0.0.0 by default AND writes its own DNAT rules, bypassing the host
+      # firewall (same trap documented on the postgres service in docker-compose.yml).
+      - "${GLITCHTIP_BIND:-127.0.0.1}:${GLITCHTIP_PORT:-8000}:8000"
+
+volumes:
+  glitchtipdata:
+```
+
+- [ ] **Step 2: Append the env block to `deploy/.env.example`**
+
+```bash
+# ---- Observability (optional): self-hosted GlitchTip error tracking + timings ----
+# Enabled only when you run the overlay:
+#   docker compose -f docker-compose.yml -f docker-compose.observability.yml up -d
+# Leaving SENTRY_DSN / Sentry__Dsn empty keeps the worker and API completely uninstrumented.
+
+# Full external URL INCLUDING the scheme. Django derives its CSRF trusted origins from it; get this
+# wrong and every login fails with a misleading "wrong password".
+GLITCHTIP_DOMAIN=https://errors.dev.example.com
+GLITCHTIP_SECRET_KEY=
+GLITCHTIP_POSTGRES_PASSWORD=
+# Host port for the outer reverse proxy. Keep the bind on 127.0.0.1 unless the proxy is off-box.
+GLITCHTIP_PORT=8000
+GLITCHTIP_BIND=127.0.0.1
+
+# GlitchTip's own SMTP credentials, deliberately separate from the app's EMAIL__* settings so a
+# technical-contact address can diverge from the app's sender without one change breaking the other.
+# Format: smtp://user:password@host:port
+GLITCHTIP_EMAIL_URL=
+GLITCHTIP_FROM_EMAIL=
+
+# DuckDB cold storage (Parquet) in MinIO. MUST be its OWN bucket, never a prefix inside `recordings`:
+# a platform restore wipes the recordings bucket and would silently destroy the telemetry archive.
+# Use a scoped MinIO key, NOT the root credentials - root would give an observability tool full
+# read/write access to every user's audio.
+GLITCHTIP_COLD_STORAGE_BUCKET=glitchtip
+GLITCHTIP_MINIO_ACCESS_KEY=
+GLITCHTIP_MINIO_SECRET_KEY=
+
+# DSNs issued by the GlitchTip UI after creating the projects. Empty = that runtime reports nothing.
+SENTRY_DSN=
+SENTRY_API_DSN=
+SENTRY_ENVIRONMENT=development
+SENTRY_TRACES_SAMPLE_RATE=1.0
+```
+
+- [ ] **Step 3: Create the scoped MinIO bucket and access key on the dev box**
+
+Run against the dev box's MinIO. This is a one-time operational step, not a repo change.
+
+```bash
+mc alias set devminio http://localhost:9002 "$MINIO_ROOT_USER" "$MINIO_ROOT_PASSWORD"
+mc mb devminio/glitchtip
+```
+
+Then create a policy file `glitchtip-policy.json` limiting access to that bucket alone:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": ["s3:*"],
+      "Resource": ["arn:aws:s3:::glitchtip", "arn:aws:s3:::glitchtip/*"]
+    }
+  ]
+}
+```
+
+```bash
+mc admin policy create devminio glitchtip-only glitchtip-policy.json
+mc admin user add devminio glitchtip-svc "$(openssl rand -hex 24)"
+mc admin policy attach devminio glitchtip-only --user glitchtip-svc
+```
+
+Put the resulting access key and secret into `GLITCHTIP_MINIO_ACCESS_KEY` / `GLITCHTIP_MINIO_SECRET_KEY` in the dev box's `deploy/.env`.
+
+Verify the key genuinely cannot reach the audio:
+
+```bash
+mc alias set gtcheck http://localhost:9002 glitchtip-svc "<the secret>"
+mc ls gtcheck/recordings
+```
+
+Expected: **Access Denied**. If it lists objects, the policy is wrong - stop and fix it before continuing.
+
+- [ ] **Step 4: Configure the outer nginx proxy for `errors.dev.<domain>`**
+
+Add a DNS A record and a TLS certificate for the hostname first. Then add this server block to the outer proxy. The `map` goes at `http` level, outside `server`; nginx refuses to start with "unknown variable connection_upgrade" if it is missing, and many configs already declare it - do not declare it twice.
+
+```nginx
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+}
+
+server {
+    listen 443 ssl;
+    server_name errors.dev.example.com;
+
+    # TLS config as per the existing app server blocks.
+
+    location / {
+        proxy_pass http://127.0.0.1:8000;
+
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        # Load-bearing. GlitchTip is Django: without this every login fails with a CSRF error that
+        # presents as a wrong password. Same trap apps/web/nginx.conf documents for OpenIddict.
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # Minidumps and source-map bundles are far larger than nginx's 1 MB default.
+        client_max_body_size 100m;
+        proxy_read_timeout 300s;
+        proxy_send_timeout 300s;
+
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade    $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+    }
+}
+```
+
+Reload with `nginx -t && nginx -s reload`.
+
+- [ ] **Step 5: Bring it up on dev and verify**
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.observability.yml up -d glitchtip-postgres glitchtip
+```
+
+Human sign-off checklist - all five must pass:
+
+1. `https://errors.dev.<domain>` loads the GlitchTip UI over HTTPS.
+2. Creating the first user and **logging in succeeds** (this is the CSRF/`X-Forwarded-Proto` check).
+3. A password-reset email arrives (the SMTP check).
+4. Two projects created: `diariz-worker` and `diariz-api`; both DSNs recorded in the dev `deploy/.env`.
+5. `mc ls gtcheck/recordings` still returns Access Denied.
+
+- [ ] **Step 6: Update the architecture doc**
+
+In `docs/Overall_Synopsis_of_Platform.md`, add GlitchTip as an **optional** component: what it is, that it is opt-in via the overlay compose file, its own Postgres and MinIO bucket, the shared Redis on DB index 1, and that it is deployed per-environment with no sharing between dev and prod. Note explicitly that a co-located GlitchTip cannot report that the box itself is down.
+
+Do **not** touch `docs/Data_Schema.md` (GlitchTip owns its own database), the README Features table, `docs/features.md`, or the About-box `CAPABILITIES` - nothing user-visible changes.
+
+- [ ] **Step 7: Bump the version and add the release entry**
+
+Set `0.174.1` in all five files: `version.json`, `apps/web/package.json`, `apps/desktop/package.json`, `src/Diariz.Api/Diariz.Api.csproj` (`<Version>`), `integrations/n8n-nodes-diariz/package.json`.
+
+Add to the top of `RELEASES` in `apps/web/src/lib/releases.ts` (get the real PR number first - see the PR grouping section):
+
+```ts
+{
+  version: "0.174.1",
+  date: "2026-07-31",
+  pr: 389,
+  headline: "Optional self-hosted error tracking",
+  summary:
+    "Adds an optional Docker Compose overlay for GlitchTip, a self-hosted error-tracking and " +
+    "performance-monitoring service. Nothing is reported unless you run the overlay and set a DSN, " +
+    "so existing deployments are unchanged. This release only stands the service up - the worker and " +
+    "API start reporting to it in later releases.",
+  added: [
+    "Optional GlitchTip overlay (deploy/docker-compose.observability.yml) with its own database and object-storage bucket.",
+  ],
+},
+```
+
+- [ ] **Step 8: Verify the version mirrors test passes**
+
+```bash
+cd apps/web && npm test -- versionMirrors releases
+```
+
+Expected: PASS. If it fails, a mirror was missed.
+
+- [ ] **Step 9: Commit, push, open the PR**
+
+```bash
+git checkout -b feat/observability-glitchtip-infra
+git add deploy/docker-compose.observability.yml deploy/.env.example docs/Overall_Synopsis_of_Platform.md version.json apps/web/package.json apps/desktop/package.json src/Diariz.Api/Diariz.Api.csproj integrations/n8n-nodes-diariz/package.json apps/web/src/lib/releases.ts
+git commit -m "feat: optional GlitchTip observability overlay"
+git push -u origin feat/observability-glitchtip-infra
+```
+
+PR description must state: **server redeploy only, no desktop release**, and that the overlay is opt-in so existing deployments are unaffected.
+
+---
+
+### Task 2: Worker PII scrubber (TDD)
+
+**Files:**
+- Create: `src/Diariz.Worker/telemetry.py`
+- Test: `src/Diariz.Worker/tests/test_telemetry.py`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `telemetry.scrub(obj) -> object` (recursive, pure), `telemetry.is_sensitive_key(key: str) -> bool`, `telemetry.REDACTED: str`. Task 3 consumes `scrub` as the SDK's `before_send`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `src/Diariz.Worker/tests/test_telemetry.py`:
+
+```python
+"""Tests for the telemetry scrubber. This is the code whose bugs leak customer data, so it is
+tested directly rather than through the SDK."""
+import telemetry
+
+
+def test_is_sensitive_key_matches_secrets_case_insensitively():
+    assert telemetry.is_sensitive_key("HF_TOKEN")
+    assert telemetry.is_sensitive_key("callback_secret")
+    assert telemetry.is_sensitive_key("S3_SECRET_KEY")
+    assert telemetry.is_sensitive_key("Authorization")
+    assert telemetry.is_sensitive_key("password")
+
+
+def test_is_sensitive_key_matches_content_bearing_fields():
+    assert telemetry.is_sensitive_key("text")
+    assert telemetry.is_sensitive_key("transcript")
+    assert telemetry.is_sensitive_key("segments")
+    assert telemetry.is_sensitive_key("summary")
+
+
+def test_is_sensitive_key_keeps_the_identifiers_needed_to_diagnose():
+    # A scrubber that redacts everything is useless. These must survive.
+    assert not telemetry.is_sensitive_key("transcription_id")
+    assert not telemetry.is_sensitive_key("recording_id")
+    assert not telemetry.is_sensitive_key("blob_key")
+    assert not telemetry.is_sensitive_key("model")
+    assert not telemetry.is_sensitive_key("language")
+
+
+def test_scrub_redacts_nested_values_and_preserves_ids():
+    event = {
+        "extra": {
+            "transcription_id": "tid-1",
+            "blob_key": "user/abc.wav",
+            "text": "the confidential meeting content",
+        },
+        "request": {"headers": {"Authorization": "Bearer abc", "Accept": "application/json"}},
+    }
+
+    cleaned = telemetry.scrub(event)
+
+    assert cleaned["extra"]["transcription_id"] == "tid-1"
+    assert cleaned["extra"]["blob_key"] == "user/abc.wav"
+    assert cleaned["extra"]["text"] == telemetry.REDACTED
+    assert cleaned["request"]["headers"]["Authorization"] == telemetry.REDACTED
+    assert cleaned["request"]["headers"]["Accept"] == "application/json"
+
+
+def test_scrub_walks_into_lists():
+    event = {"segments": [{"text": "secret words"}], "breadcrumbs": [{"message": "ok", "text": "leak"}]}
+
+    cleaned = telemetry.scrub(event)
+
+    assert cleaned["segments"] == telemetry.REDACTED
+    assert cleaned["breadcrumbs"][0]["message"] == "ok"
+    assert cleaned["breadcrumbs"][0]["text"] == telemetry.REDACTED
+
+
+def test_scrub_does_not_mutate_the_input():
+    event = {"extra": {"text": "content"}}
+
+    telemetry.scrub(event)
+
+    assert event["extra"]["text"] == "content"
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+cd src/Diariz.Worker && python -m pytest tests/test_telemetry.py -v
+```
+
+Expected: FAIL, collection error `ModuleNotFoundError: No module named 'telemetry'`.
+
+- [ ] **Step 3: Write the minimal implementation**
+
+Create `src/Diariz.Worker/telemetry.py`:
+
+```python
+"""Optional error + performance reporting to a Sentry-compatible endpoint (GlitchTip).
+
+Completely inert unless SENTRY_DSN is set: the SDK is imported lazily inside init(), so a
+deployment without a DSN pays nothing and the test suite never needs sentry_sdk installed.
+
+This module is the ONLY place that knows about sentry_sdk. worker.py and pipeline.py call the
+context managers below, which are no-ops when reporting is off.
+"""
+
+REDACTED = "[redacted]"
+
+# Exact key names that carry meeting content. Transcripts are this application's payload; an event
+# that leaks one cannot be un-sent.
+_DENY_EXACT = frozenset({
+    "text", "transcript", "transcription", "segments", "words", "summary",
+    "minutes", "content", "authorization", "cookie", "cookies",
+})
+
+# Substrings that mark a credential regardless of the surrounding name.
+_DENY_SUBSTRING = ("secret", "token", "password", "api_key", "apikey", "access_key")
+
+
+def is_sensitive_key(key: str) -> bool:
+    """True when a field with this name must never leave the process."""
+    lowered = str(key).lower()
+    if lowered in _DENY_EXACT:
+        return True
+    return any(marker in lowered for marker in _DENY_SUBSTRING)
+
+
+def scrub(obj):
+    """Recursively redact sensitive values. Pure: returns a new structure, never mutates the input."""
+    if isinstance(obj, dict):
+        return {k: (REDACTED if is_sensitive_key(k) else scrub(v)) for k, v in obj.items()}
+    if isinstance(obj, (list, tuple)):
+        return [scrub(item) for item in obj]
+    return obj
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+cd src/Diariz.Worker && python -m pytest tests/test_telemetry.py -v
+```
+
+Expected: all six PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git checkout -b feat/observability-worker
+git add src/Diariz.Worker/telemetry.py src/Diariz.Worker/tests/test_telemetry.py
+git commit -m "feat: add worker telemetry scrubber"
+```
+
+---
+
+### Task 3: Worker telemetry init, release lookup and span helpers (TDD)
+
+**Files:**
+- Modify: `src/Diariz.Worker/telemetry.py`
+- Modify: `src/Diariz.Worker/tests/test_telemetry.py`
+- Modify: `src/Diariz.Worker/requirements.txt`
+
+**Interfaces:**
+- Consumes: `scrub` from Task 2; `config.API_BASE_URL` from `config.py`.
+- Produces: `telemetry.init() -> bool`, `telemetry.release() -> str | None`, and two context managers `telemetry.transaction(name: str, op: str = "queue.task")` and `telemetry.span(op: str, name: str)`. Task 4 consumes all four.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `src/Diariz.Worker/tests/test_telemetry.py`:
+
+```python
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def test_init_returns_false_and_does_nothing_when_dsn_is_empty(monkeypatch):
+    monkeypatch.setenv("SENTRY_DSN", "")
+    # If init tried to use the SDK with no DSN this would raise, proving the guard ran first.
+    monkeypatch.setitem(sys.modules, "sentry_sdk", None)
+
+    assert telemetry.init() is False
+
+
+def test_init_returns_false_when_dsn_is_only_whitespace(monkeypatch):
+    monkeypatch.setenv("SENTRY_DSN", "   ")
+    monkeypatch.setitem(sys.modules, "sentry_sdk", None)
+
+    assert telemetry.init() is False
+
+
+def test_init_configures_the_sdk_with_pii_off_and_the_scrubber(monkeypatch):
+    fake_sdk = MagicMock()
+    monkeypatch.setitem(sys.modules, "sentry_sdk", fake_sdk)
+    monkeypatch.setenv("SENTRY_DSN", "https://key@errors.example/1")
+    monkeypatch.setenv("SENTRY_ENVIRONMENT", "development")
+    monkeypatch.setenv("SENTRY_TRACES_SAMPLE_RATE", "0.5")
+    monkeypatch.setattr(telemetry, "release", lambda: "0.174.2")
+
+    assert telemetry.init() is True
+
+    kwargs = fake_sdk.init.call_args.kwargs
+    assert kwargs["dsn"] == "https://key@errors.example/1"
+    assert kwargs["send_default_pii"] is False
+    assert kwargs["before_send"] is telemetry._before_send
+    assert kwargs["before_send_transaction"] is telemetry._before_send
+    assert kwargs["traces_sample_rate"] == 0.5
+    assert kwargs["environment"] == "development"
+    assert kwargs["release"] == "0.174.2"
+
+
+def test_before_send_scrubs_the_event():
+    event = {"extra": {"text": "content", "transcription_id": "tid-1"}}
+
+    cleaned = telemetry._before_send(event, None)
+
+    assert cleaned["extra"]["text"] == telemetry.REDACTED
+    assert cleaned["extra"]["transcription_id"] == "tid-1"
+
+
+def test_release_reads_the_version_the_api_reports(monkeypatch):
+    class FakeResponse:
+        def json(self):
+            return {"status": "ok", "version": "0.174.2"}
+
+    monkeypatch.setattr(telemetry.requests, "get", lambda url, timeout: FakeResponse())
+
+    assert telemetry.release() == "0.174.2"
+
+
+def test_release_returns_none_when_the_api_is_unreachable(monkeypatch):
+    def boom(url, timeout):
+        raise OSError("connection refused")
+
+    monkeypatch.setattr(telemetry.requests, "get", boom)
+
+    assert telemetry.release() is None
+
+
+def test_span_and_transaction_are_no_ops_when_reporting_is_off(monkeypatch):
+    monkeypatch.setattr(telemetry, "_enabled", False)
+
+    with telemetry.transaction("job"):
+        with telemetry.span("op.stage", "stage"):
+            pass  # must not raise, and must not need sentry_sdk
+
+
+def test_span_delegates_to_the_sdk_when_enabled(monkeypatch):
+    fake_sdk = MagicMock()
+    monkeypatch.setitem(sys.modules, "sentry_sdk", fake_sdk)
+    monkeypatch.setattr(telemetry, "_enabled", True)
+
+    with telemetry.span("op.asr", "ASR"):
+        pass
+
+    fake_sdk.start_span.assert_called_once_with(op="op.asr", name="ASR")
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+cd src/Diariz.Worker && python -m pytest tests/test_telemetry.py -v
+```
+
+Expected: FAIL - `AttributeError: module 'telemetry' has no attribute 'init'` (and the same for `release`, `span`, `transaction`, `requests`).
+
+- [ ] **Step 3: Write the minimal implementation**
+
+Add to the top of `src/Diariz.Worker/telemetry.py`, below the docstring:
+
+```python
+import logging
+import os
+from contextlib import contextmanager
+
+import requests
+
+from config import config
+
+log = logging.getLogger("telemetry")
+
+# Set by init(). The context managers below check it rather than importing sentry_sdk, so a worker
+# with no DSN never loads the SDK at all.
+_enabled = False
+```
+
+Then append below `scrub`:
+
+```python
+def _before_send(event, hint):
+    """SDK hook. Scrubs every outgoing event and transaction."""
+    return scrub(event)
+
+
+def release() -> str | None:
+    """The platform version this worker serves, read from the API's /health.
+
+    The worker image carries no version of its own - version.json lives at the repo root, outside the
+    worker's build context - and hard-coding one in .env would drift silently the moment someone
+    forgot to bump it. The API already reports the canonical version, and the worker already waits
+    for the API to be healthy before it starts.
+    """
+    try:
+        return requests.get(f"{config.API_BASE_URL}/health", timeout=5).json().get("version")
+    except Exception:  # noqa: BLE001 - a missing release tag must never stop the worker starting
+        log.debug("Could not read the platform version from the API", exc_info=True)
+        return None
+
+
+def init() -> bool:
+    """Start reporting if SENTRY_DSN is set. Returns whether reporting is on."""
+    global _enabled
+
+    dsn = os.getenv("SENTRY_DSN", "").strip()
+    if not dsn:
+        return False
+
+    import sentry_sdk
+
+    sentry_sdk.init(
+        dsn=dsn,
+        environment=os.getenv("SENTRY_ENVIRONMENT", "development"),
+        release=release(),
+        traces_sample_rate=float(os.getenv("SENTRY_TRACES_SAMPLE_RATE", "1.0")),
+        # Never attach request bodies, headers or user identifiers automatically.
+        send_default_pii=False,
+        before_send=_before_send,
+        before_send_transaction=_before_send,
+    )
+    _enabled = True
+    log.info("Error reporting enabled")
+    return True
+
+
+@contextmanager
+def transaction(name: str, op: str = "queue.task"):
+    """Wrap one unit of work as a reportable transaction. A no-op when reporting is off."""
+    if not _enabled:
+        yield
+        return
+    import sentry_sdk
+    with sentry_sdk.start_transaction(op=op, name=name):
+        yield
+
+
+@contextmanager
+def span(op: str, name: str):
+    """Time one stage inside the current transaction. A no-op when reporting is off."""
+    if not _enabled:
+        yield
+        return
+    import sentry_sdk
+    with sentry_sdk.start_span(op=op, name=name):
+        yield
+```
+
+- [ ] **Step 4: Add the dependency**
+
+Append to `src/Diariz.Worker/requirements.txt`:
+
+```
+# Optional error + performance reporting (GlitchTip / Sentry-compatible). Imported lazily and only
+# when SENTRY_DSN is set, so it costs nothing on deployments that do not use it.
+sentry-sdk==X.Y.Z
+```
+
+Replace `X.Y.Z` with a real version - do not leave it as written. Determine it with:
+
+```bash
+pip index versions sentry-sdk
+```
+
+Take the newest release on the `2.x` line (the 2 line is what the GlitchTip docs target) and write that exact number into the file. Do **not** add it to `requirements-test.txt` - the tests stub it, exactly as `conftest.py` already stubs `whisperx`.
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+```bash
+cd src/Diariz.Worker && python -m pytest tests/test_telemetry.py -v
+```
+
+Expected: all PASS.
+
+- [ ] **Step 6: Run the whole worker suite for regressions**
+
+```bash
+cd src/Diariz.Worker && python -m pytest
+```
+
+Expected: all PASS, no warnings.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/Diariz.Worker/telemetry.py src/Diariz.Worker/tests/test_telemetry.py src/Diariz.Worker/requirements.txt
+git commit -m "feat: add worker telemetry init and span helpers"
+```
+
+---
+
+### Task 4: Wire telemetry into the worker and pipeline (TDD)
+
+**Files:**
+- Modify: `src/Diariz.Worker/worker.py` (`main`, `handle`, `handle_merge`)
+- Modify: `src/Diariz.Worker/pipeline.py` (`transcribe`)
+- Modify: `src/Diariz.Worker/tests/test_worker.py`
+
+**Interfaces:**
+- Consumes: `telemetry.init`, `telemetry.transaction`, `telemetry.span` from Task 3.
+- Produces: no new API. Behaviour: a job runs inside a transaction named `transcribe` or `audio-merge`, with spans `download`, `asr`, `align`, `diarize`, `embeddings`, `callback`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `src/Diariz.Worker/tests/test_worker.py`:
+
+```python
+def test_handle_runs_inside_a_telemetry_transaction(monkeypatch, tmp_path):
+    audio = tmp_path / "audio.wav"
+    audio.write_text("fake")
+    monkeypatch.setattr(worker.storage, "download", lambda key: str(audio))
+    monkeypatch.setattr(worker.pipeline, "transcribe",
+                        lambda path, min_s=None, max_s=None: {"language": "en", "segments": [], "speakers": []})
+    monkeypatch.setattr(worker.callback, "post_result", lambda *a, **k: None)
+
+    names = []
+
+    import contextlib
+
+    @contextlib.contextmanager
+    def fake_transaction(name, op="queue.task"):
+        names.append(name)
+        yield
+
+    monkeypatch.setattr(worker.telemetry, "transaction", fake_transaction)
+
+    worker.handle(_job("tid-t"))
+
+    assert names == ["transcribe"]
+
+
+def test_handle_reports_a_failure_and_still_cleans_up(monkeypatch, tmp_path):
+    audio = tmp_path / "audio.wav"
+    audio.write_text("fake")
+    monkeypatch.setattr(worker.storage, "download", lambda key: str(audio))
+
+    def boom(path, min_s=None, max_s=None):
+        raise RuntimeError("model load failed")
+
+    monkeypatch.setattr(worker.pipeline, "transcribe", boom)
+
+    posted = {}
+    monkeypatch.setattr(worker.callback, "post_failure",
+                        lambda tid, msg: posted.update(tid=tid, msg=msg))
+
+    captured = []
+    monkeypatch.setattr(worker.telemetry, "capture_exception", lambda e: captured.append(e))
+
+    worker.handle(_job("tid-f"))
+
+    # The existing contract is unchanged: the API is still told, and the temp file is still removed.
+    assert posted["tid"] == "tid-f"
+    assert not os.path.exists(str(audio))
+    # And the exception is now also reported.
+    assert len(captured) == 1
+    assert isinstance(captured[0], RuntimeError)
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+cd src/Diariz.Worker && python -m pytest tests/test_worker.py -v
+```
+
+Expected: FAIL - `AttributeError: module 'worker' has no attribute 'telemetry'`.
+
+- [ ] **Step 3: Add `capture_exception` to the telemetry module**
+
+Append to `src/Diariz.Worker/telemetry.py`:
+
+```python
+def capture_exception(error: BaseException) -> None:
+    """Report an exception that the worker has caught and handled. A no-op when reporting is off."""
+    if not _enabled:
+        return
+    import sentry_sdk
+    sentry_sdk.capture_exception(error)
+```
+
+- [ ] **Step 4: Wire it into `worker.py`**
+
+Add `import telemetry` to the import block in `src/Diariz.Worker/worker.py`, alongside `import storage`.
+
+Replace the body of `handle` with:
+
+```python
+def handle(job: dict) -> None:
+    transcription_id = job["TranscriptionId"]
+    blob_key = job["BlobKey"]
+    log.info("Processing transcription %s (blob=%s, model=%s)",
+             transcription_id, blob_key, job.get("Model"))
+
+    audio_path = None
+    started = time.monotonic()
+    try:
+        with telemetry.transaction("transcribe"):
+            with telemetry.span("storage.download", "download"):
+                audio_path = storage.download(blob_key)
+            result = pipeline.transcribe(audio_path, job.get("MinSpeakers"), job.get("MaxSpeakers"))
+            # Full-pipeline wall-clock time (download + transcribe + diarize + embed), reported to the API.
+            processing_ms = int((time.monotonic() - started) * 1000)
+            with telemetry.span("http.client", "callback"):
+                callback.post_result(transcription_id, result["language"], result["segments"],
+                                     result.get("speakers"), result.get("duration_ms"), processing_ms)
+    except Exception as e:  # noqa: BLE001 - report and continue
+        log.exception("Job failed for transcription %s", transcription_id)
+        telemetry.capture_exception(e)
+        callback.post_failure(transcription_id, str(e))
+    finally:
+        if audio_path and os.path.exists(audio_path):
+            os.remove(audio_path)
+```
+
+Apply the same two changes to `handle_merge` - wrap its body in `with telemetry.transaction("audio-merge"):` and add `telemetry.capture_exception(e)` immediately before `callback.post_merge_failure(...)`.
+
+In `main`, add the init call immediately after `torch_compat.restore_legacy_torch_load()`:
+
+```python
+    # Optional error/performance reporting. Inert unless SENTRY_DSN is set.
+    telemetry.init()
+```
+
+- [ ] **Step 5: Add stage spans in `pipeline.py`**
+
+Add `import telemetry` to the import block. Then in `transcribe`, wrap each numbered stage. The existing comments stay; only the indentation and the `with` lines are new:
+
+```python
+    # 1. Transcribe (backend-pluggable: faster-whisper on CUDA, openai-whisper on AMD ROCm)
+    with telemetry.span("ai.asr", "asr"):
+        asr = _asr(audio)
+    language = asr["language"]
+
+    # 2. Word-level alignment
+    with telemetry.span("ai.align", "align"):
+        align_model, metadata = _get_align(language)
+        result = whisperx.align(
+            asr["segments"], align_model, metadata, audio, config.DEVICE,
+            return_char_alignments=False)
+
+    # 3. Diarization (with optional speaker-count hints) + speaker assignment
+    with telemetry.span("ai.diarize", "diarize"):
+        diarize_segments = _diarize(audio, min_speakers, max_speakers)
+        result = whisperx.assign_word_speakers(diarize_segments, result)
+
+    segments = _shape_segments(result["segments"])
+
+    # 4. Per-speaker voiceprint embeddings (for identification against enrolled people)
+    with telemetry.span("ai.embeddings", "embeddings"):
+        speakers = _extract_speakers(audio, segments)
+```
+
+- [ ] **Step 6: Run the tests to verify they pass**
+
+```bash
+cd src/Diariz.Worker && python -m pytest -v
+```
+
+Expected: all PASS, including the pre-existing `test_worker.py` and `test_pipeline.py` tests, with no warnings.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/Diariz.Worker/worker.py src/Diariz.Worker/pipeline.py src/Diariz.Worker/telemetry.py src/Diariz.Worker/tests/test_worker.py
+git commit -m "feat: report worker exceptions and stage timings"
+```
+
+---
+
+### Task 5: Worker deploy config, docs and release (PR 2 close-out)
+
+**Files:**
+- Modify: `deploy/docker-compose.yml` (worker service `environment`)
+- Modify: `docs/Overall_Synopsis_of_Platform.md`
+- Modify: `version.json` + the four mirrors
+- Modify: `apps/web/src/lib/releases.ts`
+
+**Interfaces:**
+- Consumes: `SENTRY_DSN`, `SENTRY_ENVIRONMENT`, `SENTRY_TRACES_SAMPLE_RATE` from `.env` (Task 1).
+- Produces: nothing consumed by later tasks.
+
+- [ ] **Step 1: Pass the DSN to the worker**
+
+In `deploy/docker-compose.yml`, append to the `worker` service's `environment` block:
+
+```yaml
+      # Optional error + performance reporting. Empty DSN = completely inert.
+      SENTRY_DSN: ${SENTRY_DSN:-}
+      SENTRY_ENVIRONMENT: ${SENTRY_ENVIRONMENT:-development}
+      SENTRY_TRACES_SAMPLE_RATE: ${SENTRY_TRACES_SAMPLE_RATE:-1.0}
+```
+
+- [ ] **Step 2: Update the architecture doc**
+
+In `docs/Overall_Synopsis_of_Platform.md`, record that the worker optionally reports to GlitchTip: one transaction per job with `download`/`asr`/`align`/`diarize`/`embeddings`/`callback` spans, that the release tag is read from the API's `/health` at startup, and that all events pass through `telemetry.scrub` so no transcript content is transmitted.
+
+- [ ] **Step 3: Bump to 0.174.2 and add the release entry**
+
+Same five files as Task 1 Step 7. Add to the top of `RELEASES`:
+
+```ts
+{
+  version: "0.174.2",
+  date: "2026-07-31",
+  pr: 390,
+  headline: "Transcription worker reports failures and stage timings",
+  summary:
+    "When a GlitchTip DSN is configured, the transcription worker now reports unhandled failures " +
+    "with a full traceback, and times each stage of a job - download, transcription, alignment, " +
+    "diarization, voiceprints and callback - so a slow job can be traced to the stage responsible. " +
+    "Transcript content is never transmitted. Deployments without a DSN are unchanged.",
+  added: [
+    "Optional worker error reporting and per-stage timings.",
+  ],
+},
+```
+
+- [ ] **Step 4: Verify the full worker suite and the mirrors test**
+
+```bash
+cd src/Diariz.Worker && python -m pytest
+```
+
+```bash
+cd apps/web && npm test -- versionMirrors releases
+```
+
+Expected: both PASS.
+
+- [ ] **Step 5: Verify on dev end to end**
+
+Deploy the branch to dev with `SENTRY_DSN` set to the `diariz-worker` DSN from Task 1. Then:
+
+1. Upload a short recording and let it transcribe. In GlitchTip, the `transcribe` transaction appears with a span breakdown whose stages account for the wall-clock time.
+2. Force a failure (e.g. temporarily set `WHISPER_MODEL` to a nonexistent model and restart the worker). A traceback appears in GlitchTip, and the recording still moves to a failed state in the app - the existing behaviour must be unchanged.
+3. **Inspect the captured event's payload in the GlitchTip UI and confirm no transcript text appears anywhere in it.** This is the gate on the whole approach; do not proceed to Task 6 until it passes.
+
+- [ ] **Step 6: Commit, push, open the PR**
+
+```bash
+git add deploy/docker-compose.yml docs/Overall_Synopsis_of_Platform.md version.json apps/web/package.json apps/desktop/package.json src/Diariz.Api/Diariz.Api.csproj integrations/n8n-nodes-diariz/package.json apps/web/src/lib/releases.ts
+git commit -m "feat: wire worker telemetry into the deployment"
+git push -u origin feat/observability-worker
+```
+
+PR description: **server redeploy only, no desktop release.**
+
+---
+
+### Task 6: API telemetry options and scrubber (TDD)
+
+**Files:**
+- Modify: `src/Diariz.Api/Configuration/AppOptions.cs`
+- Create: `src/Diariz.Api/Services/SentryScrubber.cs`
+- Test: `tests/Diariz.Api.Tests/SentryScrubberTests.cs`
+- Test: `tests/Diariz.Api.Tests/TelemetryOptionsTests.cs`
+
+**Interfaces:**
+- Consumes: nothing.
+- Produces: `Diariz.Api.Configuration.TelemetryOptions` with `Section = "Sentry"`, `Dsn`, `BrowserDsn`, `Environment`, `TracesSampleRate`, `Enabled`; and `Diariz.Api.Services.SentryScrubber` with `Redacted`, `IsSensitiveKey(string)`, `Scrub(SentryEvent)`. Task 7 consumes both.
+
+**Naming note:** the class is `TelemetryOptions`, **not** `SentryOptions` - `Sentry.AspNetCore` already exports a type by that name and the collision would force awkward qualification throughout `Program.cs`. The configuration *section* is still `"Sentry"`.
+
+- [ ] **Step 1: Write the failing options test**
+
+Create `tests/Diariz.Api.Tests/TelemetryOptionsTests.cs`:
+
+```csharp
+using Diariz.Api.Configuration;
+
+namespace Diariz.Api.Tests;
+
+public class TelemetryOptionsTests
+{
+    [Fact]
+    public void Enabled_IsFalse_WhenDsnIsEmpty()
+    {
+        Assert.False(new TelemetryOptions().Enabled);
+    }
+
+    [Fact]
+    public void Enabled_IsFalse_WhenDsnIsOnlyWhitespace()
+    {
+        Assert.False(new TelemetryOptions { Dsn = "   " }.Enabled);
+    }
+
+    [Fact]
+    public void Enabled_IsTrue_WhenDsnIsSet()
+    {
+        Assert.True(new TelemetryOptions { Dsn = "https://key@errors.example/1" }.Enabled);
+    }
+
+    [Fact]
+    public void TracesSampleRate_DefaultsToCapturingEverything()
+    {
+        // This deployment's volume is small; the SDK docs' 1% advice targets high-traffic sites.
+        Assert.Equal(1.0, new TelemetryOptions().TracesSampleRate);
+    }
+}
+```
+
+- [ ] **Step 2: Write the failing scrubber test**
+
+Create `tests/Diariz.Api.Tests/SentryScrubberTests.cs`:
+
+```csharp
+using Diariz.Api.Services;
+using Sentry;   // SentryEvent; reaches the test project transitively via the API project reference
+
+namespace Diariz.Api.Tests;
+
+public class SentryScrubberTests
+{
+    [Theory]
+    [InlineData("Authorization")]
+    [InlineData("X-Worker-Secret")]
+    [InlineData("Cookie")]
+    [InlineData("password")]
+    [InlineData("ApiKey")]
+    [InlineData("Summarization__ApiKey")]
+    public void IsSensitiveKey_MatchesCredentials(string key)
+    {
+        Assert.True(SentryScrubber.IsSensitiveKey(key));
+    }
+
+    [Theory]
+    [InlineData("text")]
+    [InlineData("transcript")]
+    [InlineData("segments")]
+    [InlineData("summary")]
+    [InlineData("minutes")]
+    public void IsSensitiveKey_MatchesMeetingContent(string key)
+    {
+        Assert.True(SentryScrubber.IsSensitiveKey(key));
+    }
+
+    [Theory]
+    [InlineData("recordingId")]
+    [InlineData("transcriptionId")]
+    [InlineData("blobKey")]
+    [InlineData("userId")]
+    [InlineData("model")]
+    public void IsSensitiveKey_KeepsTheIdentifiersNeededToDiagnose(string key)
+    {
+        // A scrubber that redacts everything is useless.
+        Assert.False(SentryScrubber.IsSensitiveKey(key));
+    }
+
+    [Fact]
+    public void Scrub_RedactsSensitiveExtras_AndKeepsIdentifiers()
+    {
+        var e = new SentryEvent();
+        e.SetExtra("transcriptionId", "tid-1");
+        e.SetExtra("text", "the confidential meeting content");
+
+        var cleaned = SentryScrubber.Scrub(e);
+
+        Assert.NotNull(cleaned);
+        Assert.Equal("tid-1", cleaned!.Extra["transcriptionId"]);
+        Assert.Equal(SentryScrubber.Redacted, cleaned.Extra["text"]);
+    }
+}
+```
+
+- [ ] **Step 3: Run both tests to verify they fail**
+
+```bash
+dotnet test tests/Diariz.Api.Tests --filter "FullyQualifiedName~TelemetryOptions|FullyQualifiedName~SentryScrubber"
+```
+
+Expected: FAIL to compile - `TelemetryOptions` and `SentryScrubber` do not exist.
+
+- [ ] **Step 4: Add the options class**
+
+Append to `src/Diariz.Api/Configuration/AppOptions.cs`, following the `DictationOptions` pattern already in that file:
+
+```csharp
+/// <summary>Optional error + performance reporting to a Sentry-compatible endpoint (GlitchTip).
+/// Named TelemetryOptions rather than SentryOptions because Sentry.AspNetCore already exports that
+/// type name; the configuration section is still "Sentry".</summary>
+public class TelemetryOptions
+{
+    public const string Section = "Sentry";
+
+    /// <summary>Server-side DSN. Empty disables reporting entirely - no SDK init, no network calls.</summary>
+    public string Dsn { get; set; } = "";
+
+    /// <summary>DSN handed to the browser at runtime. Public by design (it ships in the JS bundle).
+    /// Unused until the SPA is instrumented; kept here so both live in one section.</summary>
+    public string BrowserDsn { get; set; } = "";
+
+    public string Environment { get; set; } = "development";
+
+    /// <summary>Fraction of requests traced. Defaults to everything: this deployment's volume is small,
+    /// and the SDK docs' 1% recommendation targets high-traffic sites.</summary>
+    public double TracesSampleRate { get; set; } = 1.0;
+
+    /// <summary>True when a DSN is configured; otherwise the SDK is never initialised.</summary>
+    public bool Enabled => !string.IsNullOrWhiteSpace(Dsn);
+}
+```
+
+- [ ] **Step 5: Add the `Sentry.AspNetCore` package**
+
+```bash
+dotnet add src/Diariz.Api/Diariz.Api.csproj package Sentry.AspNetCore
+```
+
+This pins whatever the current release is; check the resulting `<PackageReference>` line matches the style of its neighbours in the csproj.
+
+- [ ] **Step 6: Write the scrubber**
+
+Create `src/Diariz.Api/Services/SentryScrubber.cs`:
+
+```csharp
+using Sentry;   // SentryEvent
+
+namespace Diariz.Api.Services;
+
+/// <summary>Redacts credentials and meeting content from telemetry events before they leave the
+/// process. Distinct from <see cref="LogSanitizer"/>, which defends against log-injection in log
+/// lines rather than against disclosure.
+///
+/// Transcripts, summaries and minutes are this application's payload, and an event that leaks one
+/// cannot be un-sent - so this denies by default and keeps only the identifiers needed to diagnose
+/// a failure.</summary>
+public static class SentryScrubber
+{
+    public const string Redacted = "[redacted]";
+
+    // Exact field names that carry meeting content.
+    private static readonly HashSet<string> DenyExact = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "text", "transcript", "transcription", "segments", "words", "summary",
+        "minutes", "note", "notes", "content", "authorization", "cookie", "cookies",
+    };
+
+    // Substrings marking a credential regardless of the surrounding name.
+    private static readonly string[] DenySubstring =
+        ["secret", "token", "password", "apikey", "api_key", "accesskey", "access_key"];
+
+    /// <summary>True when a field with this name must never leave the process.</summary>
+    public static bool IsSensitiveKey(string key)
+    {
+        if (string.IsNullOrEmpty(key)) return false;
+        if (DenyExact.Contains(key)) return true;
+        foreach (var marker in DenySubstring)
+            if (key.Contains(marker, StringComparison.OrdinalIgnoreCase)) return true;
+        return false;
+    }
+
+    /// <summary>SDK hook: redact in place and return the event.</summary>
+    public static SentryEvent? Scrub(SentryEvent e)
+    {
+        foreach (var key in e.Extra.Keys.ToList())
+            if (IsSensitiveKey(key)) e.SetExtra(key, Redacted);
+
+        foreach (var key in e.Request.Headers.Keys.ToList())
+            if (IsSensitiveKey(key)) e.Request.Headers[key] = Redacted;
+
+        // Request bodies can contain anything a user typed or dictated. Never send one.
+        e.Request.Data = null;
+
+        return e;
+    }
+}
+```
+
+- [ ] **Step 7: Run the tests to verify they pass**
+
+```bash
+dotnet test tests/Diariz.Api.Tests --filter "FullyQualifiedName~TelemetryOptions|FullyQualifiedName~SentryScrubber"
+```
+
+Expected: all PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git checkout -b feat/observability-api
+git add src/Diariz.Api/Configuration/AppOptions.cs src/Diariz.Api/Services/SentryScrubber.cs src/Diariz.Api/Diariz.Api.csproj tests/Diariz.Api.Tests/TelemetryOptionsTests.cs tests/Diariz.Api.Tests/SentryScrubberTests.cs
+git commit -m "feat: add API telemetry options and event scrubber"
+```
+
+---
+
+### Task 7: Wire Sentry into the API host
+
+**Files:**
+- Modify: `src/Diariz.Api/Program.cs`
+
+**Interfaces:**
+- Consumes: `TelemetryOptions` and `SentryScrubber` from Task 6.
+- Produces: nothing consumed by later tasks.
+
+**No new test.** `Program.cs` is not unit-testable in this codebase, and the testable units (`Enabled`, `IsSensitiveKey`, `Scrub`) are already covered by Task 6. Verification is the dev end-to-end check in Task 8.
+
+- [ ] **Step 1: Move the version lookup earlier**
+
+`appVersion` is currently computed at `src/Diariz.Api/Program.cs:515`, after the app is built, but Sentry needs it at host-configuration time. Cut this line:
+
+```csharp
+var appVersion = System.Reflection.Assembly.GetExecutingAssembly().GetName().Version?.ToString(3) ?? "0.0.0";
+```
+
+and paste it immediately **above** `var builder = WebApplication.CreateBuilder(args);`. The existing `/health` endpoint keeps using it unchanged.
+
+- [ ] **Step 2: Register the options section**
+
+In the `---- Options ----` block, alongside the other `Configure` calls:
+
+```csharp
+builder.Services.Configure<TelemetryOptions>(builder.Configuration.GetSection(TelemetryOptions.Section));
+```
+
+- [ ] **Step 3: Initialise the SDK**
+
+Immediately after the `ForwardedHeadersOptions` block (Sentry must be configured on the host before the rest of the pipeline is built):
+
+```csharp
+// ---- Optional error + performance reporting (GlitchTip / Sentry-compatible) ----
+// Entirely absent unless a DSN is configured, matching how Summarization/Dictation are gated.
+var telemetry = builder.Configuration.GetSection(TelemetryOptions.Section).Get<TelemetryOptions>()
+                ?? new TelemetryOptions();
+if (telemetry.Enabled)
+{
+    builder.WebHost.UseSentry(o =>
+    {
+        o.Dsn = telemetry.Dsn;
+        o.Environment = telemetry.Environment;
+        o.Release = appVersion;
+        o.TracesSampleRate = telemetry.TracesSampleRate;
+        // Never attach request bodies, cookies or user identifiers automatically.
+        o.SendDefaultPii = false;
+        o.SetBeforeSend(SentryScrubber.Scrub);
+    });
+}
+```
+
+Outbound `HttpClient` calls need no extra registration: the ASP.NET Core integration instruments clients created by `IHttpClientFactory` automatically, which covers every `AddHttpClient` registration in this file.
+
+- [ ] **Step 4: Build and run the whole solution's tests**
+
+```bash
+dotnet build Diariz.slnx
+```
+
+Expected: builds clean. Building the solution (not just the unit test project) is deliberate - a unit-only run misses integration and CodeQL compile breaks.
+
+```bash
+dotnet test tests/Diariz.Api.Tests
+```
+
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Diariz.Api/Program.cs
+git commit -m "feat: report API exceptions and request timings"
+```
+
+---
+
+### Task 8: API deploy config, docs and release (PR 3 close-out)
+
+**Files:**
+- Modify: `deploy/docker-compose.yml` (api service `environment`)
+- Modify: `docs/Overall_Synopsis_of_Platform.md`
+- Modify: `version.json` + the four mirrors
+- Modify: `apps/web/src/lib/releases.ts`
+
+- [ ] **Step 1: Pass the DSN to the API**
+
+In `deploy/docker-compose.yml`, append to the `api` service's `environment` block:
+
+```yaml
+      # Optional error + performance reporting. Empty DSN = completely inert.
+      Sentry__Dsn: ${SENTRY_API_DSN:-}
+      Sentry__Environment: ${SENTRY_ENVIRONMENT:-development}
+      Sentry__TracesSampleRate: ${SENTRY_TRACES_SAMPLE_RATE:-1.0}
+```
+
+- [ ] **Step 2: Update the architecture doc**
+
+Record in `docs/Overall_Synopsis_of_Platform.md` that the API optionally reports unhandled exceptions and request transactions (p50/p95 per endpoint), that outbound LLM calls appear as child spans via `IHttpClientFactory` instrumentation, that the release tag is the assembly version reported at `/health`, and that every event passes through `SentryScrubber`.
+
+- [ ] **Step 3: Bump to 0.174.3 and add the release entry**
+
+```ts
+{
+  version: "0.174.3",
+  date: "2026-07-31",
+  pr: 391,
+  headline: "API reports errors and endpoint timings",
+  summary:
+    "When a GlitchTip DSN is configured, the API now reports unhandled exceptions and records how " +
+    "long each endpoint takes, including the time spent waiting on the configured language model. " +
+    "Request bodies, credentials and meeting content are stripped before anything is sent. " +
+    "Deployments without a DSN are unchanged.",
+  added: [
+    "Optional API error reporting and per-endpoint timings.",
+  ],
+},
+```
+
+- [ ] **Step 4: Verify**
+
+```bash
+dotnet build Diariz.slnx
+```
+
+```bash
+dotnet test tests/Diariz.Api.Tests
+```
+
+```bash
+cd apps/web && npm test -- versionMirrors releases
+```
+
+Expected: all PASS.
+
+- [ ] **Step 5: Verify on dev end to end**
+
+Deploy to dev with `SENTRY_API_DSN` set to the `diariz-api` DSN. Then:
+
+1. Trigger a handled-but-logged failure (e.g. request a summary with a deliberately wrong `Summarization__ApiBase`) and confirm the exception appears with a stack trace.
+2. Browse the app normally, then confirm the GlitchTip performance view lists endpoints with counts and p50/p95.
+3. Run one summarisation and confirm the outbound LLM call appears as a **child span** of the request transaction with its own duration.
+4. **Inspect a captured event's payload and confirm no request body, no `Authorization` header and no meeting content appears.**
+
+- [ ] **Step 6: Commit, push, open the PR**
+
+```bash
+git add deploy/docker-compose.yml docs/Overall_Synopsis_of_Platform.md version.json apps/web/package.json apps/desktop/package.json src/Diariz.Api/Diariz.Api.csproj integrations/n8n-nodes-diariz/package.json apps/web/src/lib/releases.ts
+git commit -m "feat: wire API telemetry into the deployment"
+git push -u origin feat/observability-api
+```
+
+PR description: **server redeploy only, no desktop release.**
+
+---
+
+### Task 9: Sub-phase 1d - promote to production
+
+Operational only. **No code, no PR, no version bump** - the code shipped in PRs 1-3 and is inert on prod until a DSN is set.
+
+**Gate:** do not start until dev has been running instrumented for long enough to have captured real failures, and those events have been reviewed for leaked content.
+
+- [ ] **Step 1: Review what dev actually captured**
+
+Open the last two weeks of dev events and read the payloads. Confirm: no transcript, summary, minutes or note text; no `Authorization` or `X-Worker-Secret` values; no request bodies. If anything leaked, stop - fix the scrubber and its tests as a new PR before touching prod.
+
+- [ ] **Step 2: Stand up the prod instance**
+
+Repeat Task 1 Steps 3-5 against the prod box, with prod's own values: its own `GLITCHTIP_SECRET_KEY`, its own Postgres password, its own MinIO scoped key, `errors.<domain>`, and `SENTRY_ENVIRONMENT=production`. Nothing is shared with dev.
+
+Confirm again that the prod GlitchTip MinIO key cannot list `recordings`.
+
+- [ ] **Step 3: Enable the worker first, alone**
+
+Set only `SENTRY_DSN` (worker) in prod's `.env` and restart the worker. Leave `SENTRY_API_DSN` empty. Watch for a day: the worker handles far fewer, far more predictable payloads than the API, so it is the safer first exposure.
+
+- [ ] **Step 4: Enable the API**
+
+Set `SENTRY_API_DSN` and restart the API. Review the first day's events for leaked content specifically - the API sees far more user input than the worker does.
+
+- [ ] **Step 5: Set retention**
+
+Choose and apply an event-retention period on both instances. Do not leave it at the default. Dev can be aggressive; prod should be a deliberate choice recorded in `docs/Overall_Synopsis_of_Platform.md`.
+
+- [ ] **Step 6: Confirm the phase-2 prerequisite**
+
+Check whether the outer proxy preserves the `sentry-trace` and `baggage` request headers on the **app's** hostname. This is needed before the SPA work, and it fails silently, so verify it now rather than discovering it later. Record the answer in the phase 2 plan.
+
+---
+
+## Self-review notes
+
+**Spec coverage.** Every section of the design spec maps to a task: topology and per-box composition (Task 1), MinIO bucket + scoped key constraint (Task 1 Steps 2-3), sub-phase 1a (Task 1), 1b (Tasks 2-5), 1c (Tasks 6-8), 1d (Task 9), off-by-default (Tasks 2/3/6), sampling (Task 6 Step 4), email separation (Task 1 Step 2), registration disabled (Task 1 Step 1), nginx and the CSRF trap (Task 1 Step 4), PII policy (Tasks 2, 6, and the verification gates in 5/8/9), testing (Tasks 2, 3, 4, 6), release obligations (Tasks 1, 5, 8), risks (mitigations distributed across the above).
+
+**Deliberately out of scope**, per the spec: API-to-worker trace linking across the Redis stream, the SPA, source maps, and the `AboutModal.tsx` disclaimers question (a phase 2 decision).
+
+**Deferred pins.** Two dependency versions are resolved at implementation time rather than written here - `sentry-sdk` (Task 3 Step 4, with the command to determine it) and `Sentry.AspNetCore` (Task 6 Step 5, via `dotnet add package`). Writing a specific version into this plan would ship a stale number.

--- a/docs/superpowers/specs/2026-07-31-observability-glitchtip-design.md
+++ b/docs/superpowers/specs/2026-07-31-observability-glitchtip-design.md
@@ -1,0 +1,415 @@
+# Observability: crash reporting and API timings via GlitchTip
+
+**Date:** 2026-07-31
+**Status:** Design, awaiting implementation plan
+
+## 1. Goal
+
+Answer two questions that Diariz currently cannot answer:
+
+1. **What broke for a user?** - the stack trace, the release it happened on, and what the user
+   was doing beforehand, across all three runtimes (Python worker, .NET API, React SPA).
+2. **Where is time going?** - per-endpoint latency (p50/p95), per-stage timings inside a
+   transcription job, and how long outbound LLM calls actually take.
+
+Today there is no answer to either. The API logs to console with the default `ILogger`, the
+worker logs to stdout, and browser errors reach an `ErrorBoundary` that shows the user a message
+and tells nobody.
+
+## 2. Approach and why
+
+**GlitchTip, using the official Sentry SDKs.** GlitchTip is MIT-licensed and speaks the Sentry
+wire protocol, so the real `sentry-sdk` / `Sentry.AspNetCore` / `@sentry/react` packages point at
+a self-hosted endpoint.
+
+It covers **both** goals in one container. Its performance monitoring records transactions and
+spans with count, average, p50 and p95 per transaction group, and drills into a span breakdown to
+show which child operation consumed the time. Sentry SDKs propagate `sentry-trace` and `baggage`
+automatically over HTTP, so a browser XHR and the ASP.NET Core request it triggered land in a
+single trace.
+
+### Rejected alternatives
+
+**OpenTelemetry Collector plus a trace backend (Jaeger / Tempo / SigNoz).** Rejected for now.
+The collector stores nothing, so it obliges a storage backend, and the realistic options mean
+running ClickHouse or the four-service Grafana stack on a box already carrying a ~12 GB worker
+image and GPU models. Since GlitchTip already provides p50/p95 spans, this buys very little
+today. OTel browser instrumentation is also still described by its own project as experimental
+and subject to breaking change, so it is the weaker option for the SPA specifically.
+
+This is not a dead end: GlitchTip 6.2 (June 2026) added native OTLP log ingest at `/v1/logs`
+with no SDK required, and announced span and trace ingest as forthcoming. If OTel is wanted
+later, GlitchTip is on a path to receive it rather than be replaced by it.
+
+**SigNoz alone.** OTel-native and genuinely one product, but ClickHouse is a substantial tenant
+and its error-tracking experience is weaker than the Sentry-style flow that is the primary goal.
+
+### Known limitations, accepted
+
+- **No session tracking.** GlitchTip does not support sessions; `autoSessionTracking` must be
+  `false`. No release-health or crash-free-rate metrics.
+- **No session replay.** No DOM playback of a user's session.
+- **Co-located GlitchTip cannot report that the box is down.** It reports application failures,
+  not infrastructure death. Uptime monitoring is a separate concern and out of scope.
+- **Spans require DuckDB enabled** (`GLITCHTIP_ENABLE_DUCKDB`). DuckDB runs inside the existing
+  Python process writing Parquet, so this costs about 128 MB of RAM and no extra container.
+
+## 3. Non-goals
+
+- Infrastructure metrics (CPU, GPU, VRAM, queue depth). Prometheus can be added later without
+  conflicting; it is not part of this work.
+- Uptime / external availability monitoring.
+- Session replay.
+- Linking API traces to worker traces across the Redis stream (see 5.3).
+- Any change to what end users see. This is operational tooling; the app's feature set is
+  unchanged.
+
+## 4. Architecture
+
+### 4.1 Two fully independent instances
+
+Dev and prod each get their own GlitchTip, own database, own retention, own subdomain. Nothing is
+shared, and events are not distinguished by an `environment` tag on a shared instance. Dev is the
+proving ground: every sub-phase lands on dev and is observed there before prod is touched.
+
+### 4.2 Per-box composition
+
+| Component | Choice | Rationale |
+| --- | --- | --- |
+| GlitchTip | Single all-in-one container (web + worker) | ~256 MB minimum, 512 MB recommended |
+| Database | **Its own Postgres container**, own volume | See below |
+| Cache / queue | **Reuse the existing Redis**, DB index 1 (`redis://redis:6379/1`) | `VALKEY_URL` is optional and only affects cache and task speed; small blast radius, saves a container |
+| Cold storage | **Reuse MinIO**, dedicated `glitchtip` bucket | See 4.4 |
+| Delivery | Optional overlay `deploy/docker-compose.observability.yml` | Mirrors the existing standalone `docker-compose.rocm.yml` pattern; core stack unchanged for anyone who does not want this |
+
+**Why a separate Postgres rather than a second database in `pgvector/pgvector:pg16`:**
+
+1. The platform backup/restore feature (`MaintenanceController`, with its `CurrentFormat` fence)
+   operates on the app database. Co-locating an observability tool's tables entangles two things
+   with completely different retention and recovery semantics.
+2. The `postgres` image only auto-creates `POSTGRES_DB`. A second database needs an init script in
+   `/docker-entrypoint-initdb.d`, which **only runs on a fresh volume** - so on the existing dev
+   and prod boxes it would silently not run, forcing a hand-run `CREATE DATABASE` on live systems.
+3. GlitchTip requires Postgres 14+; Diariz is pinned to 16 for pgvector. Decoupling means
+   GlitchTip's upgrade cycle never blocks Diariz's.
+
+Cost is roughly 50-100 MB of RAM. Accepted.
+
+### 4.3 Instrumentation points
+
+| Where | Package | Captures |
+| --- | --- | --- |
+| Python worker | `sentry-sdk` | Unhandled exceptions; one transaction per job with a span per stage |
+| API | `Sentry.AspNetCore` | Unhandled exceptions; request transactions with p50/p95 per endpoint; outbound HttpClient calls as spans |
+| SPA | `@sentry/react` | Unhandled exceptions and `ErrorBoundary` captures; browser tracing linking XHR to the API request |
+
+### 4.4 MinIO cold storage: a verified constraint
+
+DuckDB cold storage writes Parquet to either a local directory or an S3 bucket
+(`GLITCHTIP_COLD_STORAGE_BUCKET`). Reusing the existing MinIO keeps telemetry in the same place
+as everything else durable.
+
+**Verified against the code:** the platform backup enumerates blobs through
+`_storage.ListKeysAsync` (`MaintenanceController.cs`), and `AudioStorage` scopes every S3 call to
+the single configured `Storage:Bucket`. Restore wipes using that same bucket-scoped listing. A
+separate bucket is therefore invisible to both backup and restore.
+
+**Two rules follow, and both are load-bearing:**
+
+- **GlitchTip must use its own bucket, never a prefix inside `recordings`.** Restore *wipes* the
+  recordings bucket before repopulating it. Cold storage placed under a prefix there would be
+  silently destroyed by any restore.
+- **GlitchTip must have its own MinIO access key**, scoped by policy to its own bucket. Handing it
+  `MINIO_ROOT_USER` would give an observability tool full read/write access to every user's audio.
+
+## 5. Phase 1: worker and API
+
+### 5.1 Sub-phase 1a - infrastructure, dev only
+
+Bring up GlitchTip on the dev box. Create the organisation, two projects (`diariz-worker`,
+`diariz-api`), and issue their DSNs. Configure the outer proxy subdomain and TLS. Nothing is
+instrumented yet.
+
+This exists as its own step so that the container, the SMTP wiring, the CSRF/proxy configuration
+and the TLS certificate are all proven before any application code changes.
+
+**Done when:** the GlitchTip UI is reachable over HTTPS on its subdomain, login works, a password
+reset email arrives, and a manually-sent test event appears.
+
+### 5.2 Sub-phase 1b - Python worker
+
+Highest value in the whole plan. The worker is where the genuinely nasty failures live (model
+load, CUDA, pyannote), and per-stage timings are information that does not exist today in any
+form.
+
+- Initialise `sentry-sdk` when `SENTRY_DSN` is set; complete no-op when it is empty.
+- Unhandled exceptions in `worker.handle` reported with job context (transcription id, model,
+  blob key) - **never** transcript content.
+- One transaction per job, with a span per stage: blob download, ASR, alignment, diarization,
+  speaker embeddings, callback POST.
+- Release tag from the platform version.
+
+**Done when:** a deliberately failed job appears in GlitchTip with a usable traceback, and a
+successful job shows a stage breakdown that accounts for the wall-clock time.
+
+### 5.3 Sub-phase 1c - API
+
+- `Sentry.AspNetCore` initialised when the DSN is set; no-op when empty.
+- Unhandled exceptions, plus request transactions giving p50/p95 per endpoint.
+- `SentryHttpMessageHandler` on the outbound `HttpClient`s so summarisation, embedding and
+  dictation calls to the LLM endpoint each become a span. Given the history of LM Studio
+  slowness and runtime faults, "is this us or the model" becomes directly answerable.
+- Release tag from `version.json`, which the API already reports at `GET /health`.
+
+**Deliberately excluded: API-to-worker trace linking.** That hop is a Redis stream job, not an
+HTTP call, so propagation would mean adding trace headers to the `TranscriptionJob` payload - a
+cross-boundary contract change requiring both the .NET producer and the Python consumer to move
+in lockstep. Each side gets its own traces for now. Revisit only if the disconnect proves
+painful in practice.
+
+**Done when:** a forced 500 appears with a stack trace, the endpoint list shows p50/p95, and a
+summarisation request shows the outbound LLM call as a timed child span.
+
+### 5.4 Sub-phase 1d - promote to prod
+
+Stand up the prod instance and enable the worker and API DSNs there. Gated on dev having run
+long enough to trust the scrubbing rules, with a deliberate review of what actually arrived.
+
+## 6. Phase 2: SPA
+
+Phase 2 inherits the scrubbing rules proven server-side in phase 1. That is the reason for this
+ordering: browser payloads start flowing only after the redaction approach has been observed
+working on real traffic.
+
+### 6.1 Sub-phase 2a - errors, and the DSN delivery problem
+
+**The DSN cannot be a build-time variable.** The SPA today uses no `import.meta.env` values at
+all, and `apps/web/Dockerfile` takes only `BUILD_COMMIT`. Everything environment-specific is
+same-origin by design. A `VITE_SENTRY_DSN` baked at build time would produce one image carrying
+one DSN, so dev and prod would either share a GlitchTip instance - which this design explicitly
+rejects - or require two separate image builds of identical source.
+
+**Resolution: the API serves the browser DSN at runtime.** Browser DSNs are public by design
+(they are embedded in shipped JavaScript), so this leaks nothing. The API already serves
+`GET /health` with the version; the browser DSN is served the same way, from
+`Sentry__BrowserDsn`. One image, two environments, correct DSN in each, and the existing
+"empty value disables the feature" convention is preserved.
+
+**Accepted trade-off:** the SDK cannot initialise until that config request returns, so errors
+thrown during the very earliest boot are missed. If those turn out to matter, the mitigation is a
+minimal inline `window.onerror` buffer replayed once the SDK is live. Start without it.
+
+`@sentry/react` wired into the existing `ErrorBoundary`, with `autoSessionTracking: false`
+(GlitchTip has no sessions). Errors only; tracing off.
+
+Note this also covers the **Electron desktop app**, which loads the SPA from the server origin -
+desktop users' renderer errors arrive for free. Main-process errors would need `@sentry/electron`
+and are out of scope.
+
+### 6.2 Sub-phase 2b - browser tracing
+
+Enable browser tracing so XHR calls link to their API request in one trace. axios uses XHR, so
+instrumentation is automatic.
+
+**Prerequisite:** confirm the outer proxy does not strip `sentry-trace` and `baggage` headers on
+the app's own hostname. If it does, tracing degrades into disconnected halves and **fails
+silently** - no error, just permanently unlinked traces.
+
+### 6.3 Sub-phase 2c - source maps
+
+The web build currently ships `sourcemap: true` to production, meaning the application source is
+publicly readable. Switch to uploading source maps to GlitchTip per release
+(`glitchtip-cli sourcemaps inject` / `upload`) and stop serving them. This yields readable stack
+traces **and** closes the source exposure - a security improvement independent of observability.
+
+Requires a CI step keyed to the release version.
+
+## 7. Configuration
+
+### 7.1 Off by default
+
+Every integration is disabled unless its DSN is set, exactly as `Summarization__ApiBase` and
+`Dictation__ApiBase` already work. Nobody who clones the repo gets telemetry they did not ask
+for, and the test suites are unaffected.
+
+| Variable | Applies to | Empty means |
+| --- | --- | --- |
+| `SENTRY_DSN` | Worker | No SDK init, no-op |
+| `Sentry__Dsn` | API | No SDK init, no-op |
+| `Sentry__BrowserDsn` | API, served to the SPA at runtime (see 6.1) | No SDK init, no-op |
+| `Sentry__TracesSampleRate` / `SENTRY_TRACES_SAMPLE_RATE` | API, worker | Defaults per below |
+
+### 7.2 Sampling
+
+GlitchTip's documentation recommends `tracesSampleRate: 0.01` because every HTTP request becomes
+a transaction. **That advice targets high-traffic sites and does not apply here.** Diariz volume
+is small enough to capture everything: errors at 100%, traces at 100% initially, with the knob
+exposed so it can be turned down if event volume ever becomes a problem. Disk cost is roughly
+30 GB per *million* events, which this deployment will not approach.
+
+### 7.3 Email
+
+GlitchTip requires `EMAIL_URL` (or a provider API key) for invitations and password resets.
+
+**Its own credentials in `.env`**, distinct from the app's MailKit settings, under a technical
+contact address. In practice the same mailbox today, but the two are allowed to diverge without
+one change breaking the other.
+
+### 7.4 Registration
+
+`ENABLE_USER_REGISTRATION=false` and `ENABLE_ORGANIZATION_CREATION=false` on both instances.
+These are internal tools on public subdomains; open registration on them is not wanted.
+
+## 8. Outer nginx proxy
+
+Each environment gets its own subdomain, proxied by the existing outer TLS-terminating proxy to
+the GlitchTip container's port 8000. This is a **separate server block** from the app's, pointing
+at a different upstream - GlitchTip does not sit behind the `web` container's nginx.
+
+### 8.1 Prerequisites
+
+- DNS A record per environment.
+- A TLS certificate covering each new hostname (or a wildcard).
+- The GlitchTip port reachable from the proxy: published on the host, or on a shared Docker
+  network if the proxy runs in Docker.
+
+### 8.2 The failure that will happen if this is got wrong
+
+GlitchTip is Django. **Django rejects logins with a CSRF failure when the proxy does not tell it
+the original scheme was HTTPS.** This is the single most common self-hosting problem, and it
+presents as "my password is wrong" rather than anything mentioning proxies.
+
+Two things must agree:
+
+- `GLITCHTIP_DOMAIN` must be the **full external URL including scheme** (`https://errors.example`),
+  because Django derives its trusted CSRF origins from it.
+- The proxy must send `X-Forwarded-Proto: https`.
+
+The existing `apps/web/nginx.conf` already solves the identical problem for OpenIddict with its
+`$client_proto` map, and the comment there explains the same trap. The new server block needs the
+same discipline.
+
+### 8.3 Server block shape
+
+```nginx
+# At http level, NOT inside server. Required by the Connection header below - nginx will refuse
+# to start with "unknown variable connection_upgrade" if this is omitted. Many configs already
+# have it; do not declare it twice.
+map $http_upgrade $connection_upgrade {
+    default upgrade;
+    ''      close;
+}
+
+server {
+    listen 443 ssl;
+    server_name errors.dev.example.com;
+
+    # TLS config as per the existing app server blocks.
+
+    location / {
+        proxy_pass http://127.0.0.1:8000;   # or the container name on a shared Docker network
+
+        proxy_set_header Host              $host;
+        proxy_set_header X-Real-IP         $remote_addr;
+        proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
+        # Load-bearing: without this Django 403s every login with a CSRF failure.
+        proxy_set_header X-Forwarded-Proto $scheme;
+
+        # Source map bundles and minidumps are far larger than nginx's 1 MB default.
+        client_max_body_size 100m;
+
+        # Source map uploads can be slow on a large bundle.
+        proxy_read_timeout 300s;
+        proxy_send_timeout 300s;
+
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade    $http_upgrade;
+        proxy_set_header Connection $connection_upgrade;
+    }
+}
+```
+
+### 8.4 A separate change to the *app's* server block
+
+Distinct from the above, and only needed for phase 2b: the **existing** app hostname's proxy
+configuration must not strip `sentry-trace` and `baggage` request headers. nginx does not strip
+arbitrary headers by default, but this deployment's outer proxy is already known to rewrite
+things, so it needs verifying rather than assuming. The failure is silent.
+
+### 8.5 Ad blockers
+
+Browser ad blockers pattern-match Sentry ingest paths and hostnames. Some proportion of browser
+events will never leave the client, with no signal that they did not. If this proves material,
+the mitigation is a same-origin tunnel through the app's own nginx. Phase 2 only - the worker and
+API are unaffected. Start without a tunnel and measure.
+
+## 9. PII policy
+
+**The highest-severity item in this plan.** Transcripts, meeting content, attendee names and email
+addresses are the application's payload. Sentry SDKs capture request bodies, breadcrumbs, headers
+and XHR URLs by default. Once sent, an event cannot be un-sent.
+
+Rules:
+
+- `SendDefaultPii = false` on every SDK.
+- An explicit `before_send` / `SetBeforeSend` scrubber on each runtime, denying by default:
+  redact request and response bodies, `Authorization`, `X-Worker-Secret`, cookies, and any field
+  carrying transcript, summary, minutes or note text.
+- Identify users by **GUID only**, never email or display name.
+- Job context may carry ids (transcription id, recording id, blob key) but never content.
+- The GlitchTip database and its MinIO bucket are in scope for the platform's data handling, and
+  retention must be bounded rather than left at default.
+
+## 10. Testing
+
+Per the project's TDD requirement, with tests written first. What genuinely earns tests:
+
+| Test | Where | Why |
+| --- | --- | --- |
+| Scrubber redacts transcript text, auth headers, cookies, emails | `Diariz.Api.Tests` and worker `pytest` | This is the code whose bugs leak customer data |
+| Scrubber preserves the ids needed for diagnosis | Both | A scrubber that redacts everything is useless |
+| Empty DSN means no init and no network call | Both | The off-by-default guarantee |
+| `worker.handle` orchestration and temp cleanup still pass with span wrapping added | Worker `pytest` | Regression guard on existing behaviour |
+| `ErrorBoundary` still renders its fallback with capture enabled | `vitest` + RTL | Phase 2; a reporting hook must not break the user-facing fallback |
+
+The SDKs themselves are not tested.
+
+## 11. Release and documentation obligations
+
+Per `CLAUDE.md`, for **every** PR in both phases:
+
+- **Version:** Build +1 (infrastructure and operational tooling, not a user-facing functional
+  enhancement). `version.json` plus all four mirrors.
+- **Release notes:** one `RELEASES[0]` entry per PR.
+- **`docs/Overall_Synopsis_of_Platform.md`:** yes - new deployable component, new external
+  dependencies, new deployment surface.
+- **`docs/Data_Schema.md`:** no - GlitchTip owns its own database and its own MinIO bucket;
+  the Diariz schema is unchanged.
+- **README Features / `docs/features.md` / About-box `CAPABILITIES`:** no - nothing user-visible
+  changes. (`AboutModal.tsx` disclaimers: to be decided, see 13.)
+- **Deployment surface:** server redeploy only. **No desktop release** in either phase - nothing
+  under `apps/desktop/src/**` or the builder config is touched.
+
+## 12. Risks
+
+| Risk | Severity | Mitigation |
+| --- | --- | --- |
+| PII leaked in event payloads | **High** - silent and irreversible | Deny-by-default scrubber, tested; dev-first rollout with a deliberate review of what arrived |
+| Outer proxy strips `sentry-trace` / `baggage` | Medium - fails silently | Verify before 2b; check for linked traces rather than assuming |
+| Django CSRF failure behind the proxy | Medium - blocks 1a, misleading symptom | `GLITCHTIP_DOMAIN` with scheme + `X-Forwarded-Proto`; see 8.2 |
+| Cold storage placed inside `recordings` | **High** - destroyed by any restore | Separate bucket, mandated in 4.4 |
+| GlitchTip holding MinIO root credentials | Medium | Dedicated scoped access key |
+| Ad blockers drop browser events | Low | Phase 2 only; measure, tunnel if material |
+| Disk growth from spans and Parquet | Low at this volume | Bounded retention set explicitly |
+| SPA bundle growth (~30-40 kB gzipped) | Low | Accepted; errors-only in 2a is smaller than with tracing |
+| Co-located GlitchTip cannot report a dead box | Accepted | Out of scope; see 2 |
+
+## 13. Open questions
+
+- **`AboutModal.tsx` disclaimers.** The project convention is to list new third-party libraries
+  there. `@sentry/react` ships in the SPA bundle in phase 2, which arguably qualifies even though
+  no user-facing capability changes. Decide before the 2a PR.
+- **Retention periods.** Not yet chosen for either environment. Dev can be aggressive; prod
+  should be deliberate rather than defaulted.
+- **SDK versions.** Pin at implementation time rather than in this document, so the plan does not
+  ship a stale version number.


### PR DESCRIPTION
Research, design and implementation plans for self-hosted crash reporting and API timings.

## What this is

Three documents, no code:

- `docs/superpowers/specs/2026-07-31-observability-glitchtip-design.md` - the design
- `docs/superpowers/plans/2026-07-31-observability-phase1-worker-api.md` - phase 1 (worker + API), **implemented in #390, #391, #392**
- `docs/superpowers/plans/2026-07-31-observability-phase2-spa.md` - phase 2 (SPA), not yet started

## Approach

**GlitchTip** (MIT, Sentry wire-compatible) covers both crash reporting and transaction/span timings from one container, using the official Sentry SDKs. An OpenTelemetry collector was considered and rejected for now: it stores nothing, so it obliges a ClickHouse or four-service Grafana backend on a box already carrying a ~12 GB worker image, and GlitchTip already provides p50/p95 spans. GlitchTip 6.2 added native OTLP log ingest with traces announced, so this is not a dead end.

Two isolated instances (dev and prod), nothing shared. Phase 1 instruments the worker and API; phase 2 the SPA, inheriting scrubbing rules proven server-side first.

## Constraints verified against the code, not assumed

- **GlitchTip cold storage must use its own MinIO bucket, never a prefix inside `recordings`.** Backup and restore are both scoped to `Storage:Bucket`, so a separate bucket is invisible to them - but restore *wipes* the recordings bucket, which would silently destroy a prefix.
- **The browser DSN cannot be a build-time variable.** The SPA uses no `import.meta.env` values and the Dockerfile takes only `BUILD_COMMIT`, so a baked DSN would force dev and prod to share one instance. The API serves it at runtime instead.
- **The JWT travels in query strings.** `@microsoft/signalr` appends `?access_token=<JWT>` to the hub URL because browsers cannot set an `Authorization` header on a WS handshake. A key-name deny-list cannot reach an opaque query string - phase 1 hit this in .NET, and phase 2's plan treats it as a first-class requirement for the browser.

## What phase 1 turned up

Worth recording, because it shaped phase 2's plan. The review chain found four ways transcripts or credentials would have leaked, each a defect in the design rather than the implementation:

1. ECAPA voiceprint vectors missing from the deny-list
2. Python stack-frame locals, keyed by variable name rather than field name
3. The .NET query string carrying the SignalR JWT
4. .NET transactions bypassing `beforeSend` entirely, on every request

Phase 2's plan carries the pattern forward explicitly: a key-name deny-list only catches what arrives as a named key, and each runtime has its own channels that bypass it.

## Release checklist

Docs-only, so no version bump and no release-notes entry. The implementation PRs carry those. `Data_Schema.md`, the README Features table, `docs/features.md` and the About-box `CAPABILITIES` are unaffected - GlitchTip owns its own database and nothing user-visible changes.

## Deployment surface

Neither - docs only. (The implementation PRs are server redeploy, no desktop release.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)