### PR TITLE
fix: stop the API-token expiry test expiring

### DIFF
--- a/tests/Diariz.Api.IntegrationTests/ApiAccessIntegrationTests.cs
+++ b/tests/Diariz.Api.IntegrationTests/ApiAccessIntegrationTests.cs
@@ -103,7 +103,21 @@ public class ApiAccessIntegrationTests(ContainersFixture fx)
         // Npgsql rejects a non-zero-offset DateTimeOffset written to a `timestamptz` column - the in-memory
         // provider used by the unit tests doesn't enforce this, so only a real-Postgres test catches it.
         var userId = await SeedUser();
-        var expires = new DateTimeOffset(2026, 8, 1, 0, 0, 0, TimeSpan.FromHours(5));
+
+        // Relative to today, NOT a literal date. This was `new DateTimeOffset(2026, 8, 1, 0, 0, 0, +05:00)`,
+        // which is 2026-07-31T19:00:00Z - so at 19:00 UTC on 2026-07-31 the test started failing on every
+        // run and stayed that way, because Create rejects an expiry that is not in the future
+        // (ApiTokensController: `exp <= DateTimeOffset.UtcNow` -> BadRequest, so `.Value` was null).
+        //
+        // Anchored to midnight rather than `UtcNow.AddDays(2)` so the value has no sub-microsecond ticks:
+        // Postgres `timestamptz` stores microseconds, and a DateTimeOffset carrying finer ticks would come
+        // back slightly different and fail the equality assertion intermittently.
+        var expires = new DateTimeOffset(DateTime.UtcNow.Date.AddDays(2), TimeSpan.Zero)
+            .ToOffset(TimeSpan.FromHours(5));
+
+        // The whole point of the test. Without this, a future edit that made `expires` UTC would leave the
+        // test passing while no longer covering anything.
+        Assert.NotEqual(TimeSpan.Zero, expires.Offset);
 
         ApiTokenCreatedDto created;
         await using (var db = fx.CreateDbContext())


### PR DESCRIPTION
`main` is currently red for every new PR. This fixes it.

## What happened

`Create_NormalizesNonUtcExpiresAt_ToUtcInstant` hardcoded:

```csharp
var expires = new DateTimeOffset(2026, 8, 1, 0, 0, 0, TimeSpan.FromHours(5));
```

`2026-08-01 00:00:00 +05:00` **is** `2026-07-31 19:00:00Z`.

`ApiTokensController` rejects an expiry that is not in the future:

```csharp
if (req.ExpiresAt is { } exp && exp <= DateTimeOffset.UtcNow)
    return BadRequest("Expiry must be in the future.");
```

So at 19:00 UTC on 2026-07-31 the request began returning `BadRequest`, `.Value` became null, and `Assert.NotNull(created)` failed. Permanently, on every branch - not intermittently.

## The evidence

The runs either side of that instant, on trees that differ by nothing relevant:

| PR | Integration job | Result |
| --- | --- | --- |
| #395 | 18:5x UTC | pass |
| #396 | **19:01:33 UTC** | **fail** |

#396 adds only markdown and shell scripts - no C# at all - which is what made it obvious the trigger was the clock rather than the diff.

## The fix

The date is now relative to today. Two details are deliberate:

**Anchored to midnight, not `UtcNow.AddDays(2)`.** Postgres `timestamptz` stores microseconds; a `DateTimeOffset` carrying finer ticks would round-trip slightly different and fail the equality assertion intermittently. That would trade a dead test for a flaky one, which is worse.

**Asserts the offset is non-zero.** That is the actual subject of the test - Npgsql rejects a non-zero-offset `DateTimeOffset` written to `timestamptz`. Without the assertion, a later edit that made the value UTC would leave the test green while covering nothing.

## Was anything else lurking?

I swept every hardcoded date literal in the test suites. The others (`AudioRetentionScheduleTests`, `EfToolsTests`, `IcsCalendarTests`, `ChatContextBuilderTests`, `ActionsPromptTests`) are fixed *inputs* compared against explicit expected values, never against `UtcNow` - so they do not rot. `ApiTokensControllerTests` already uses relative dates on both its expiry cases.

This was the only one.

## Release checklist

**No version bump.** This changes only the test suite - nothing shipped, nothing user-visible, no release note that would mean anything to a user. It is also the pragmatic choice: #395 is open and already claims 0.174.6, so bumping here would force it to rebase while `main` stays red. Say if you would rather it were a numbered release and I will redo it as 0.174.6 and move #395 to 0.174.7.

## Testing

`dotnet test tests/Diariz.Api.IntegrationTests` - 223 passed, 0 failed, locally against real Testcontainers. Reproduced the failure first, then confirmed the fix.

## Deployment surface

Neither - test-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)