### PR TITLE
ci: gate the desktop tests, cap Microsoft.OpenApi, and keep majors out of grouped Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,7 @@ updates:
     groups:
       web-deps:
         patterns: ["*"]
+        update-types: ["minor", "patch"]
 
   # Electron desktop shell.
   - package-ecosystem: "npm"
@@ -23,6 +24,12 @@ updates:
     groups:
       desktop-deps:
         patterns: ["*"]
+        update-types: ["minor", "patch"]
+    ignore:
+      # ESM-only from v9; apps/desktop/src/main.js is CommonJS and does `require("electron-store")`,
+      # which then yields a module namespace rather than the constructor. src/electronStore.test.js
+      # asserts both halves of this. Unpin only alongside converting the main process to ESM.
+      - dependency-name: "electron-store"
 
   # .NET API + Domain. Grouped so a framework bump (e.g. the ASP.NET/EF 9 -> 10 alignment) arrives as one
   # coordinated PR instead of individual bumps that can't build on their own.
@@ -33,6 +40,7 @@ updates:
     groups:
       nuget-deps:
         patterns: ["*"]
+        update-types: ["minor", "patch"]
 
   # Python transcription worker. The GPU/compat stack is deliberately pinned (see CLAUDE.md) — let
   # Dependabot watch for security advisories but do NOT open version-bump PRs for those packages.
@@ -43,11 +51,16 @@ updates:
     groups:
       worker-deps:
         patterns: ["*"]
+        update-types: ["minor", "patch"]
     ignore:
       - dependency-name: "whisperx"
       - dependency-name: "transformers"
       - dependency-name: "huggingface_hub"
       - dependency-name: "ctranslate2"
+      # 3.11+ requires Python >= 3.11, and the worker base image (nvidia/cuda ...-ubuntu22.04) ships
+      # 3.10, so there is no installable wheel - the GPU image simply stops building. requirements.txt
+      # predicted this exact Dependabot PR; the prediction was right and the ignore list was missing.
+      - dependency-name: "matplotlib"
 
   # The GitHub Actions used by the CI/desktop-release/CodeQL workflows.
   - package-ecosystem: "github-actions"
@@ -57,3 +70,4 @@ updates:
     groups:
       actions-deps:
         patterns: ["*"]
+        update-types: ["minor", "patch"]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,28 @@ jobs:
         working-directory: apps/web
         run: npm test
 
+  desktop:
+    name: Desktop (node --test)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: apps/desktop/package-lock.json
+      - name: Install
+        working-directory: apps/desktop
+        run: npm ci
+      # A GATING run of the desktop unit tests. coverage.yml also runs them, but that job is
+      # `continue-on-error: true` and ends in `|| true`, so it can never fail a PR - it exists to
+      # report coverage, not to gate. That gap let a dependency bump to an ESM-only electron-store
+      # reach a green PR while src/electronStore.test.js was failing inside the log, which is exactly
+      # the breakage that test was written to catch. Tests that cannot fail a build are decoration.
+      - name: Test
+        working-directory: apps/desktop
+        run: node --test "src/**/*.test.js"
+
   locale-gate:
     name: Locale single-language gate
     runs-on: ubuntu-latest

--- a/src/Diariz.Api/Diariz.Api.csproj
+++ b/src/Diariz.Api/Diariz.Api.csproj
@@ -25,8 +25,25 @@
     <PackageReference Include="ModelContextProtocol.AspNetCore" Version="1.4.0" />
     <!-- Direct pin to override the transitive Microsoft.OpenApi 2.0.0 (from AspNetCore.OpenApi), which has
          a high-severity advisory GHSA-v5pm-xwqc-g5wc (stack overflow on circular schema refs). 2.7.5 is the
-         first patched release on the 2.x line. -->
-    <PackageReference Include="Microsoft.OpenApi" Version="2.7.5" />
+         first patched release on the 2.x line.
+
+         The RANGE, not just a floor: 3.x MUST NOT be taken while this project targets ASP.NET Core 10.
+         Microsoft.OpenApi 3.0 made the object model read-only by interface (IOpenApiSchema,
+         IOpenApiMediaType and friends lost their setters), but ASP.NET Core 10's OpenAPI source
+         generator still emits `mediaType.Example = ...` - so the generated file simply does not
+         compile: "CS0200: Property or indexer 'IOpenApiMediaType.Example' cannot be assigned to".
+         Upstream is explicit that AspNetCore.OpenApi 10.x requires the 2.x line
+         (microsoft/OpenAPI.NET#2610); the alignment is filed as an ASP.NET Core *11* breaking change.
+
+         A bare `Version="2.7.5"` is only a MINIMUM in NuGet, and AspNetCore.OpenApi declares its own
+         dependency as an open-ended `[2.0.0, )` with no upper bound despite being incompatible - which
+         is why a routine dependency bump proposed 3.9.0 and broke every .NET job. The explicit ceiling
+         is what stops that, here, where it is enforced rather than in a bot's ignore list.
+
+         REMOVE THE CEILING when this project moves to ASP.NET Core 11 - and expect work in
+         OpenApi/OpenApiCuration.cs at the same time, since its transformers mutate the document
+         (`document.Components.SecuritySchemes ??= ...`) rather than only inspecting it. -->
+    <PackageReference Include="Microsoft.OpenApi" Version="[2.7.5,3.0.0)" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.*">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/src/Diariz.Api/packages.lock.json
+++ b/src/Diariz.Api/packages.lock.json
@@ -101,7 +101,7 @@
       },
       "Microsoft.OpenApi": {
         "type": "Direct",
-        "requested": "[2.7.5, )",
+        "requested": "[2.7.5, 3.0.0)",
         "resolved": "2.7.5",
         "contentHash": "0FA67RSnRM4tcBKqiqVu/HPdZ9+QOKbmeRjxRUGTCjPU4C0bmUhd97Dso7Yild5P7nOV6GxJ2xrK0Kv/O9xp0w=="
       },

--- a/tests/Diariz.Api.IntegrationTests/packages.lock.json
+++ b/tests/Diariz.Api.IntegrationTests/packages.lock.json
@@ -913,7 +913,7 @@
           "Microsoft.AspNetCore.Authentication.JwtBearer": "[10.*, )",
           "Microsoft.AspNetCore.Identity.EntityFrameworkCore": "[10.*, )",
           "Microsoft.AspNetCore.OpenApi": "[10.0.9, )",
-          "Microsoft.OpenApi": "[2.7.5, )",
+          "Microsoft.OpenApi": "[2.7.5, 3.0.0)",
           "MimeKit": "[4.17.0, )",
           "ModelContextProtocol.AspNetCore": "[1.4.0, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.*, )",
@@ -929,7 +929,7 @@
       "diariz.api.testsupport": {
         "type": "Project",
         "dependencies": {
-          "Diariz.Api": "[0.174.2, )"
+          "Diariz.Api": "[0.175.1, )"
         }
       },
       "diariz.domain": {

--- a/tests/Diariz.Api.TestSupport/packages.lock.json
+++ b/tests/Diariz.Api.TestSupport/packages.lock.json
@@ -693,7 +693,7 @@
           "Microsoft.AspNetCore.Authentication.JwtBearer": "[10.*, )",
           "Microsoft.AspNetCore.Identity.EntityFrameworkCore": "[10.*, )",
           "Microsoft.AspNetCore.OpenApi": "[10.0.9, )",
-          "Microsoft.OpenApi": "[2.7.5, )",
+          "Microsoft.OpenApi": "[2.7.5, 3.0.0)",
           "MimeKit": "[4.17.0, )",
           "ModelContextProtocol.AspNetCore": "[1.4.0, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.*, )",

--- a/tests/Diariz.Api.Tests/packages.lock.json
+++ b/tests/Diariz.Api.Tests/packages.lock.json
@@ -800,7 +800,7 @@
           "Microsoft.AspNetCore.Authentication.JwtBearer": "[10.*, )",
           "Microsoft.AspNetCore.Identity.EntityFrameworkCore": "[10.*, )",
           "Microsoft.AspNetCore.OpenApi": "[10.0.9, )",
-          "Microsoft.OpenApi": "[2.7.5, )",
+          "Microsoft.OpenApi": "[2.7.5, 3.0.0)",
           "MimeKit": "[4.17.0, )",
           "ModelContextProtocol.AspNetCore": "[1.4.0, )",
           "Npgsql.EntityFrameworkCore.PostgreSQL": "[10.*, )",
@@ -816,7 +816,7 @@
       "diariz.api.testsupport": {
         "type": "Project",
         "dependencies": {
-          "Diariz.Api": "[0.174.2, )"
+          "Diariz.Api": "[0.175.1, )"
         }
       },
       "diariz.domain": {


### PR DESCRIPTION
Triage of the five open Dependabot PRs turned up two problems worth fixing rather than five PRs worth clicking.

## The desktop tests could not fail a PR

PR #413 bumped `electron-store` from `^8.2.0` to `^11.0.2`. It is **ESM-only from v9**, and `apps/desktop/src/main.js` is CommonJS doing `require("electron-store")`.

`src/electronStore.test.js` exists precisely to catch that, and it **did**:

```
not ok 17 - electron-store resolves to a constructor (require works in CommonJS main)
not ok 18 - declared electron-store dependency stays on the CommonJS line (major < 9)
error: 'electron-store is ESM-only from v9; main.js is CommonJS, so pin < 9 (got "^11.0.2")'
# fail 2
```

The PR was **green**. The only place those tests run is `coverage.yml`, which is `continue-on-error: true` and ends in `|| true` - correct for a coverage job, useless as a gate. A test that cannot fail a build is decoration.

Adds a gating `Desktop (node --test)` job to `ci.yml`, alongside the other stacks' test jobs. `coverage.yml` keeps its non-gating one. Verified locally against current `main`: 99 pass, 0 fail.

## Grouped PRs mixed majors with patches

One incompatible major failed each whole batch:

| PR | Major | Result |
| --- | --- | --- |
| #416 | `typescript` 5.7 -> **7.0** | `TS2591` on `testNodeBlob.ts`; typecheck fails |
| #417 | `Microsoft.OpenApi` 2.7 -> **3.9** | `IOpenApiMediaType.Example` became read-only, but the ASP.NET Core 10.0.10 source generator still assigns to it - every .NET job fails |

Neither is a routine update. TypeScript 7 is the native port; #417 also carried `ModelContextProtocol.AspNetCore` 1.4 -> 2.0, which given the live claude.ai connector deserves reviewing on its own.

Restricting every group to `["minor", "patch"]` keeps the routine batch mergeable and brings each major in as its own PR, where it can be judged on its merits.

## Two packages that must not move, neither of which was ignored

Both were already predicted in comments, and both got proposed anyway:

- **`electron-store`** - ESM-only from v9, main process is CommonJS. `electronStore.test.js` asserts both halves.
- **`matplotlib`** - 3.11+ needs Python >= 3.11; the worker's CUDA base image ships 3.10, so there is no installable wheel and the GPU image stops building. `requirements.txt` says in as many words that "a Dependabot bump to 3.11.x will break the Docker build" - the prediction was right and the ignore list was missing.

Worth noting the worker case is invisible to CI either way: the pytest suite stubs `whisperx` and never builds the CUDA image, so PR #414 was green while carrying a change that breaks the GPU build.

## Disposition of the five

| PR | Action | Why |
| --- | --- | --- |
| #415 actions | **merged** | Green, workflow action versions only |
| #413 desktop | closed | electron-store ESM break; ignored going forward |
| #414 worker | closed | matplotlib GPU-build break; ignored going forward |
| #416 web | closed | TypeScript 7 major; will return on its own once grouping is fixed |
| #417 nuget | closed | Microsoft.OpenApi 3 major; same |

The safe parts of #413/#414/#416/#417 (electron 43.2, boto3, numpy, vite, tailwind, and the .NET patches) are not lost - they return in next month's grouped PR, which will then be mergeable.

## Release checklist

**CI-only: no version bump, no release-notes entry**, per the CLAUDE.md rules. Nothing shipped changes.

## Deployment surface

Neither.

🤖 Generated with [Claude Code](https://claude.com/claude-code)