### PR TITLE
Make the ReleaseNotes test linear instead of quadratic

### DIFF
--- a/apps/web/src/pages/ReleaseNotes.test.tsx
+++ b/apps/web/src/pages/ReleaseNotes.test.tsx
@@ -13,7 +13,14 @@ describe("ReleaseNotes", () => {
 
     const newest = RELEASES[0];
     // The list shows every release version + headline; the detail also shows the newest's headline.
-    for (const r of RELEASES) expect(screen.getAllByText(`v${r.version}`).length).toBeGreaterThan(0);
+    //
+    // Collect the rendered versions in ONE DOM traversal, then check membership. This used to call
+    // getAllByText once per release, and since each of those walks the whole tree - a tree that itself
+    // grows by one entry per release - the cost was quadratic in the number of releases shipped. It had
+    // reached ~5s locally and was intermittently blowing CI's 20s per-test timeout, which would only have
+    // got worse with every release. Same guarantee, linear cost.
+    const rendered = new Set(screen.getAllByText(/^v\d+\.\d+\.\d+$/).map((el) => el.textContent));
+    for (const r of RELEASES) expect(rendered).toContain(`v${r.version}`);
     expect(screen.getAllByText(newest.headline).length).toBeGreaterThan(0);
   });
 


### PR DESCRIPTION
Fixes the intermittent `Web (vitest)` failure. **Not caused by #450** - that PR changes only `.gitignore`. `main` itself went red at `215c5150` with the same failure, and #449 passed with the same code, which is what a load-dependent timeout looks like.

## Diagnosis

The failure is a **timeout**, not an assertion:

```
FAIL src/pages/ReleaseNotes.test.tsx > renders the fixed header, lists releases, and shows the newest by default
Error: Test timed out in 20000ms.
```

The cause is one line:

```tsx
for (const r of RELEASES) expect(screen.getAllByText(`v${r.version}`).length).toBeGreaterThan(0);
```

`getAllByText` walks the entire rendered tree. Calling it once per release, against a tree that itself grows by one entry per release, makes the assertion **quadratic in releases shipped**. `RELEASES` is now ~180 entries and growing every PR.

Locally that single test takes **4,760ms** while its sibling in the same file takes 94ms. CI ran the whole suite in 148s against 23s locally - roughly 6x slower - which puts 4.76s right on the 20s limit. Hence: passes sometimes, fails sometimes, and would fail more and more often. The recent folder-depth work added four releases, which is what pushed it over.

## Fix

Collect the rendered versions in **one** traversal, then check membership. Same guarantee, linear cost.

**4,760ms -> 232ms.**

## Verifying the assertion still bites

A faster test that no longer tests anything would be worse than the flake, so I mutation-checked it: removing a release from the page's list makes it fail with `expected [...] to include 'v0.177.0'`.

Worth recording that my **first** mutation attempt gave a false pass. I dropped the *newest* release, which still appears in the detail pane's `<h2>` - so the DOM still contained it. Only dropping a middle release exercises the list properly. Anyone editing this test should know that.

## No version bump

Test-only; nothing built or shipped changes. Same reasoning as #450. If you would rather every PR carry a Build bump without exception, say so and I will add one to both - I have deliberately kept them consistent rather than guessing differently in each.

## Deployment surface

Neither. Test-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)