### PR TITLE
docs: record the outer reverse proxy's upload settings

### DIFF
--- a/docs/Overall_Synopsis_of_Platform.md
+++ b/docs/Overall_Synopsis_of_Platform.md
@@ -231,7 +231,35 @@ three-second window the case for that work is weak.
      own `Uploads:MaxBytes` (500 MB) which is the one that produces a readable 413. The multipart one is set
      explicitly in `Program.cs` because it defaults to **128 MB** and is *not* raised by `[RequestSizeLimit]`;
      left at the default it rejected anything larger while binding the form, before the action could explain
-     why. Any outer reverse proxy needs a matching body limit too.
+     why (a 400 reading `Failed to read the request form. Multipart body length limit 134217728 exceeded`,
+     which reads as a framework fault rather than a size refusal). Fixed in 0.186.12 / PR #472; covered by
+     `UploadSizeLimitIntegrationTests`, which posts a real 132 MB body over HTTP.
+   - **The outer reverse proxy is a fifth limit, and it is not in this repo.** Anything in front of the web
+     container (an nginx-proxy-manager host, a cloud load balancer) applies its own body cap and timeouts.
+     Deployed settings, in use since 2026-08-07 and confirmed against the recording that previously tripped
+     the 128 MB multipart limit (so the size range above 128 MB is exercised; the 500 MB ceiling itself is
+     not yet):
+
+     ```nginx
+     client_max_body_size 1024m;      # match apps/web/nginx.conf; see below for why not 500m
+     proxy_read_timeout 600s;
+     proxy_send_timeout 600s;
+     proxy_request_buffering off;
+     ```
+
+     Three things worth keeping straight:
+     - **Size the proxy above the app, never at it.** `Uploads:MaxBytes` should stay the narrowest limit,
+       because the action is the only layer that can answer with "the maximum upload size is 500 MB". A proxy
+       set to `500m` both pre-empts that message with a bare nginx 413 *and* rejects a genuine 500 MB file,
+       since the multipart envelope adds a few hundred bytes on top of it.
+     - **Timeouts, not size, are the next failure.** A 500 MB upload takes minutes on a domestic connection,
+       and the API then streams it into MinIO before it answers - well past a typical 60s default, which
+       surfaces as a **504** rather than anything about size. Diagnose by the status code: 413 is a limit,
+       504 is a timeout.
+     - **`proxy_request_buffering off` matters most.** Left on, the proxy spools the whole upload to its own
+       disk before forwarding a byte - doubling the wall-clock wait and needing scratch space equal to the
+       file. (Note the distinction from the `/mcp` requirement further down: that one disables **response**
+       buffering, `proxy_buffering`, for a different reason.)
    - Job payload is JSON with **PascalCase** keys: `{ RecordingId, TranscriptionId, BlobKey, Model, MinSpeakers?, MaxSpeakers? }` —
      produced by .NET, consumed by Python.
 3. **Transcribe.** The worker `XREADGROUP`s a job, downloads the blob from MinIO to a temp file, then runs


### PR DESCRIPTION
Follow-up to #472. That PR fixed and documented the four upload size limits **inside** this repo; this
records the fifth, which is not in the repo at all - whatever reverse proxy sits in front of the web
container - now that it has been configured and the upload confirmed working in dev.

## What's added

The deployed nginx-proxy-manager values, in `docs/Overall_Synopsis_of_Platform.md` alongside the existing
four-limit list:

```nginx
client_max_body_size 1024m;
proxy_read_timeout 600s;
proxy_send_timeout 600s;
proxy_request_buffering off;
```

Plus the three things that are easy to get wrong, which is the actual value of the note:

- **Size the proxy above the app, never at it.** `Uploads:MaxBytes` should stay the narrowest limit, because
  the action is the only layer that can answer "the maximum upload size is 500 MB". A proxy set to `500m`
  both pre-empts that message with a bare nginx 413 and rejects a genuine 500 MB file, since the multipart
  envelope adds a few hundred bytes on top.
- **Timeouts, not size, are the next failure** - and they surface as a **504**, so the status code is the
  diagnostic: 413 is a limit, 504 is a timeout.
- **`proxy_request_buffering off`** is the one with a real cost attached: left on, the proxy spools the whole
  upload to its own disk before forwarding a byte. The note also distinguishes it from the `/mcp`
  requirement further down the same document, which disables **response** buffering (`proxy_buffering`) for
  an unrelated reason - two similarly-named directives, two different problems.

## Accuracy note

I first wrote that the settings were "confirmed working against a ~500 MB upload". They were not - the
confirmed case is the recording that previously tripped the 128 MB multipart limit, whose size I do not
know beyond "over 128 MB". The doc now says exactly that, and flags that the 500 MB ceiling itself is still
unexercised. A doc that overstates its evidence is worse than one that admits the gap.

## Verification

Docs-only - no code, no tests, nothing to run. Per the `CLAUDE.md` rule for a docs/CI-only PR this **skips
the version bump and release entry** (checklist items 1-3); items 4-7 are unaffected, since no feature
changed - this documents deployment detail, which is item 6's remit.

## Deployment surface

**Neither** - documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
