### PR TITLE
docs: proxy_http_version must not be set in NPM's Advanced tab

### DIFF
--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "diariz-web",
-  "version": "0.209.0",
+  "version": "0.209.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "diariz-web",
-      "version": "0.209.0",
+      "version": "0.209.1",
       "dependencies": {
         "@microsoft/signalr": "^8.0.7",
         "@scalar/api-reference-react": "^0.9.60",

--- a/docs/Overall_Synopsis_of_Platform.md
+++ b/docs/Overall_Synopsis_of_Platform.md
@@ -2507,7 +2507,7 @@ number to size against, so both proxies must simply not cap this path.
 - **On the outer reverse proxy (not in this repo):** the same settings must be applied to the app's host, and
   **per host** - a staging host added later does not inherit the production host's Advanced config, which is
   exactly how a first restore on staging met a bare nginx **413** that never reached the API. In
-  nginx-proxy-manager this goes in the host's **Advanced** tab, which is injected at `server` scope; all five
+  nginx-proxy-manager this goes in the host's **Advanced** tab, which is injected at `server` scope; all four
   are valid there and inherit into NPM's generated `location /`, which sets none of them itself:
 
   ```nginx
@@ -2515,8 +2515,22 @@ number to size against, so both proxies must simply not cap this path.
   proxy_request_buffering off;
   proxy_read_timeout 3h;
   proxy_send_timeout 3h;
-  proxy_http_version 1.1;
   ```
+
+  **Do NOT add `proxy_http_version 1.1` here, even though the inner nginx needs it and the streaming above
+  depends on it.** NPM already emits that directive at `server` scope when the host has **Websockets Support**
+  enabled, and nginx rejects a second one in the same block outright (`"proxy_http_version" directive is
+  duplicate`). NPM's failure mode makes this expensive to diagnose: rather than keeping the last good config, it
+  sets the host's file aside as `.err` and reloads without it, so the host stops existing as far as nginx is
+  concerned, the request falls through to the default server and its dummy certificate, and the browser reports
+  a **TLS name error** - which looks like a DNS or certificate problem and points nowhere near the line that
+  caused it. Confirm with `docker exec <npm-container> nginx -t` and by looking for a `.err` file in
+  `/data/nginx/proxy_host/`.
+
+  The corollary is a **coupling worth knowing about**: on this host, request streaming is supplied by the
+  Websockets Support toggle, whose stated purpose is unrelated. Turning it off would break SignalR (so it must
+  stay on regardless) and *silently* restore request buffering - a multi-GB archive spooled to the proxy's disk
+  again, with no error to explain the slowdown. If NPM ever stops emitting it, the line belongs in Advanced.
 
   This **widens the whole host**, not just `/api/maintenance/` - which is safe only because the web container's
   own nginx still enforces `1024m` on every other path, so the backstop moves one hop in rather than


### PR DESCRIPTION
Follow-up to #514. Adding `proxy_http_version 1.1;` to the outer proxy's Advanced tab, as that PR's doc instructed, took the host down with a browser TLS name error. The line was removed and the host recovered.

## Why it happened

NPM **already emits `proxy_http_version 1.1` at `server` scope** when the host has **Websockets Support** enabled. nginx rejects a second one in the same block outright - `"proxy_http_version" directive is duplicate` - so the generated config no longer parses.

The reason it surfaced as a *TLS* error rather than an obvious config error is NPM's failure handling: it does not keep the last good config on a failed test, it sets the host's file aside as `.err` and reloads without it. The hostname then matches no server block, the request falls through to the default server and its dummy certificate, and the browser reports a name/certificate failure - pointing at DNS or TLS rather than at the line that caused it.

Confirmable with `docker exec <npm-container> nginx -t` and a `.err` file in `/data/nginx/proxy_host/`.

## What changed

The documented Advanced block drops to four directives. The removal is annotated rather than silent, because a future reader has every reason to add it back - the inner nginx does need it, and the streaming behaviour genuinely depends on it.

Also recorded: on that host, request streaming is now supplied by the **Websockets Support toggle**, whose stated purpose is unrelated. Turning it off would break SignalR (so it must stay on anyway) *and* silently restore request buffering - a multi-GB archive spooled to the proxy's disk with no error to explain it. If NPM ever stops emitting the directive, the line belongs back in Advanced.

The inner `apps/web/nginx.conf` is **unaffected** - its `/api/maintenance/` location sets `proxy_http_version 1.1` in a block that sets it nowhere else, so there is no duplicate there.

## Also in here

`apps/web/package-lock.json` restamped to `0.209.1`. #514 bumped `package.json` without it, and the `chore(release): 0.209.0` commit shows the lockfile is kept in step. (`apps/desktop` and `integrations/n8n-nodes-diariz` lockfiles sit at 0.197.4, so those are clearly *not* maintained that way and are left alone.)

## Release checklist

**No version bump / release entry** - docs plus a bookkeeping correction, no shipped behaviour change. Bumping would be self-defeating here: the lockfile is being corrected *to* the released 0.209.1, and a new number would need a release note for a change users cannot observe. Happy to bump if you'd rather every PR carry one.

Items 4-7: README, `docs/features.md` and `CAPABILITIES` describe backup/restore as a capability, which has not changed; `Data_Schema.md` is untouched.

## Deployment surface

**Neither** - docs only. No redeploy, no desktop release. The operational change (removing the line) has already been made on the proxy by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
