### PR TITLE
docs(rocm): add a CPU-only baseline so the GPU numbers have scale

### DIFF
--- a/docs/Overall_Synopsis_of_Platform.md
+++ b/docs/Overall_Synopsis_of_Platform.md
@@ -2246,6 +2246,12 @@ pyannote's `ReproducibilityWarning` a red herring on AMD consumer hardware. Tran
 run to run (65/116/105 segments on identical audio) because the ROCm ASR path uses openai-whisper's
 default **temperature fallback**, which resamples any segment failing the logprob/compression thresholds.
 
+For scale, `DEVICE=cpu` on the *same* machine (16-core Zen 5) took 451.9 s / 481.4 s on the same file —
+so the GPU is worth ~**2.8x**, or an hour of audio in ~37 minutes rather than ~104. The CPU path runs at
+**0.56-0.60x realtime**, slower than the meeting itself, which is why it is documented as a fallback for
+getting the stack working rather than a way to run it. The gap is narrower than a discrete GPU would give
+because an APU's CPU and GPU share one package power budget.
+
 ## Observability (optional): GlitchTip
 
 An **optional** self-hosted error-tracking and performance-monitoring service, [GlitchTip](https://glitchtip.com/)

--- a/src/Diariz.Worker/README.md
+++ b/src/Diariz.Worker/README.md
@@ -198,6 +198,15 @@ recent, so:
 > | baseline | 167.6 s | 149.2 / 184.5 s | 166.8 s |
 > | `HSA_OVERRIDE_GFX_VERSION=11.0.0` | **381.5 s** | 165.2 / 162.2 s | 163.7 s |
 > | TF32 attempt (see below) | 197.6 s | 200.2 / 123.3 s | 161.8 s |
+> | **`DEVICE=cpu`** (same box, 16C/32T Zen 5) | 451.9 s | 481.4 s | **481.4 s** |
+>
+> **The GPU is worth about 2.8x over this machine's own CPU** (466.6 s mean vs 164.3 s), or 3.7x
+> best-against-best. Put in operational terms: an hour of audio costs roughly **37 minutes on the GPU
+> and 104 minutes on the CPU** - i.e. the CPU path runs at **0.56-0.60x realtime**, *slower than the
+> meeting it is transcribing*, so it cannot keep up with a steady recording habit and is a
+> get-it-working fallback rather than a deployment option. Note this is an APU: the CPU here is a
+> strong 16-core Zen 5 sharing one package power budget with the GPU, so the gap is narrower than a
+> discrete GPU would give.
 >
 > - **`HSA_OVERRIDE_GFX_VERSION=11.0.0` bought nothing here.** The warm means are within noise of baseline
 >   (163.7 s vs 166.8 s), and the *cold* run cost **2.3x more** (381.5 s vs 167.6 s) - consistent with


### PR DESCRIPTION
Follow-up to #517, which validated the ROCm worker on a Ryzen AI Max+ 395 / Radeon 8060S but had no
CPU number to put the GPU figures against. Docs only - no code, no version bump.

## What was measured

Same 269 s recording, same machine, `DEVICE=cpu` (16-core / 32-thread Zen 5), 2 consecutive in-process
runs. Confirmed genuinely CPU-only while it ran: load average climbing past 5 with the GPU flat at 3%.

| Config | Run 0 (cold) | Warm | Warm mean |
| --- | --- | --- | --- |
| GPU baseline | 167.6 s | 149.2 / 184.5 s | 166.8 s |
| GPU + `HSA_OVERRIDE_GFX_VERSION=11.0.0` | 381.5 s | 165.2 / 162.2 s | 163.7 s |
| GPU (third baseline sample) | 197.6 s | 200.2 / 123.3 s | 161.8 s |
| **`DEVICE=cpu`** | 451.9 s | 481.4 s | **481.4 s** |

## Why it is worth writing down

- The GPU is worth about **2.8x** over this machine's own CPU (466.6 s vs 164.3 s means), or 3.7x
  best-against-best.
- In operational terms: an hour of audio costs roughly **37 minutes on the GPU, 104 on the CPU**.
- The important part is that CPU transcription runs at **0.56-0.60x realtime** - *slower than the meeting
  it is transcribing*. It cannot keep up with a steady recording habit, which is what makes it a
  get-it-working fallback rather than a deployment option. The docs previously said "functional
  everywhere, just far slower", which is true but does not convey that it loses ground in real time.
- The 2.8x gap is narrower than a discrete GPU would give, because an APU's CPU and GPU share one
  package power budget. Worth stating so the number is not over-generalised to dGPU deployments.

## Caveat carried over from #517

The noise floor here is wide - repeated GPU runs of the same file span 123-200 s (±25%) - so these are
indicative figures, not a benchmark. The CPU/GPU gap is far outside that band; the smaller comparisons in
the table are not, and #517's README section already says so.

## Deployment surface

**Neither** - documentation only (`src/Diariz.Worker/README.md`, `docs/Overall_Synopsis_of_Platform.md`).
No desktop release, no server redeploy. Per the release checklist, a docs-only PR skips the version bump
and release-notes entry; items 4-7 are unaffected or updated here.
