### PR TITLE
docs: record the app-wide split-query default in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -89,6 +89,30 @@ API persists `Segment`s + seeds `Speaker` rows → notifies the browser over **S
   `OnModelCreating` applies the pgvector extension + column **only when the provider is Npgsql**
   (`Database.IsNpgsql()`); under other providers (the in-memory test provider) the property is
   `Ignore`d. Keep new Postgres-only model config behind that same guard so unit tests can build the model.
+- **Split queries are the app-wide default — you do not need `.AsSplitQuery()`.**
+  `DiarizDbContext.OnConfiguring` sets `QuerySplittingBehavior.SplitQuery` (0.228.4), guarded on the provider
+  being relational for the same reason as the `Database.IsNpgsql()` guards above — the in-memory unit provider
+  would otherwise get a second provider registered and throw. Several collections hang off `Recording`
+  (`Speakers`, `Actions`, `Tags`, `Transcriptions`→`Segments`), and EF's *own* default returns the **cartesian
+  product** of every sibling collection an `Include` chain names. The results are identical either way — EF
+  de-duplicates the product back into the right object graph — so it is invisible to behaviour and to any
+  results-based test, and shows up only as row count and sort spill. Measured on prod before the fix: a
+  recording-detail query returned 104,720 rows for 334 rows of real data and spilled 207 MB (0.228.2); an MCP
+  read of the same recording returned 517,825 rows and spilled 1.97 GB (0.228.3). It compounds rather than
+  plateauing, because the count is a *product* — each new action item multiplies the whole result again.
+  It was fixed by hand twice, and both audits missed sites (nine across six files), which is why the default is
+  inverted rather than left to discipline. Three things follow:
+  - **Writing a query:** just write the `Include`s. The explicit `.AsSplitQuery()` calls still in
+    `RecordingsController` and the MCP tools are redundant belt-and-braces, not a pattern to copy.
+  - **Opting out:** `.AsSingleQuery()` where one statement is genuinely needed. The trade-off the default
+    accepts is that split queries run as separate statements with no shared snapshot, so a collection could in
+    principle be read either side of a concurrent write.
+  - **The one real caveat:** a row-limiting operation (`Skip`/`Take`) on a query that also `Include`s a
+    collection needs a deterministic `OrderBy`, or the separate statements can disagree. Nothing in the app
+    does this today (every paged query projects with `Select` instead), so check it if you add one.
+  `SplitQueryIntegrationTests`, `SplitQueryEverywhereIntegrationTests` and `GlobalSplitQueryIntegrationTests`
+  pin all of the above; the last one asserts the real `Program.cs` host resolves a context with the default on,
+  since a test proving only that *test-built* contexts get it would be a false positive.
 - All user-scoped queries filter by `UserId` from the JWT `NameIdentifier` claim — preserve this
   ownership check on every recording endpoint.
 


### PR DESCRIPTION
## Why

#550 made `QuerySplittingBehavior.SplitQuery` the app-wide default, but nothing told a future reader of this repo. That change exists specifically so the cartesian-`Include` bug stops depending on anyone remembering its history — and a default nobody has written down only does half that job.

## What

One bullet in **Domain model notes**, placed next to the `Database.IsNpgsql()` guard whose reasoning `OnConfiguring` mirrors.

It covers the three things a reader actually needs, rather than restating the incident:

- **Writing a query:** just write the `Include`s. It also says explicitly that the `.AsSplitQuery()` calls still sitting in `RecordingsController` and the MCP tools are redundant belt-and-braces and **not a pattern to copy** — without that, the natural inference from seeing them on some queries and not others is that the others are deliberately single-query.
- **Opting out:** `.AsSingleQuery()`, and what trade-off the default accepts (separate statements, no shared snapshot).
- **The one real caveat:** `Skip`/`Take` on a query that also `Include`s a collection needs a deterministic `OrderBy`. Nothing in the app does this today — every paged query projects with `Select` — so it is written as a check-if-you-add-one, not a fix-this.

The measured numbers are kept (104,720 rows / 207 MB in 0.228.2; 517,825 rows / 1.97 GB in 0.228.3) because the bug's defining property is that it is *invisible* — identical results, no failing test, cost visible only as row count and sort spill. Someone deciding whether this bullet matters needs to know it cost gigabytes while looking completely correct.

## Release checklist

**Docs-only PR** — skips the version bump and release entry per the rule in CLAUDE.md itself.

- [ ] `version.json` + mirrors — no bump (docs-only)
- [ ] `RELEASES[0]` — no entry (docs-only)
- [ ] README Features / `docs/features.md` — no feature change
- [x] `docs/Overall_Synopsis_of_Platform.md` — already carries this from #550, checked and still accurate
- [ ] `Data_Schema.md` — no schema change

## Deployment surface

**Neither.** No desktop release, no server redeploy — this file ships nowhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
