### PR TITLE
docs: fixes start as a GitHub issue closed by the fixing PR

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,6 +132,22 @@ push to `main` directly, and never merge locally.** So the **default way to fini
 and open a PR** (`git push -u origin <branch>` + `gh pr create`), not a local merge - do this without asking
 unless the user says otherwise. Each PR must satisfy the release + docs rules below before it can merge.
 
+**Every fix starts as a GitHub issue and ends with the PR closing it.** When the user asks for a bug or
+problem to be fixed, **open a GitHub issue first** (`gh issue create`, before writing the fix) describing the
+symptom, and then make the PR that fixes it **close that issue automatically** by putting a closing keyword in
+the **PR body** - `Fixes #<n>` (or `Closes #<n>`) on its own line. Do this without asking. Notes:
+- **Scope:** fixes only. A new feature, chore, refactor, or docs-only change does not need an issue unless the
+  user asks for one - and if the user is *already* pointing at an existing issue, reuse that number instead of
+  opening a duplicate.
+- Write the issue from the **user-visible symptom** (what went wrong, how to reproduce, what was expected), not
+  from the fix you are about to write - it is the record of the bug, and the PR is the record of the fix.
+- **The issue consumes a number from the same sequence as PRs**, so the PR number is usually the issue number
+  + 1 - but confirm it rather than assuming (it feeds the `pr:` field in `apps/web/src/lib/releases.ts`, which
+  has to be written before `gh pr create` exists to report the real number).
+- The closing keyword must be in the **PR body**; GitHub only auto-closes from the PR description or from a
+  commit on the default branch, not from a PR title or a later comment. Verify the issue actually closed after
+  the merge, and close it by hand if it did not.
+
 **Every PR ships exactly one release: bump the version and add one release-notes entry.** The scheme
 is **Major.Minor.Build** (currently `0.x`).
 


### PR DESCRIPTION
## What

Adds a rule to the **Versioning & release notes** section of `CLAUDE.md`: when the user asks for a bug to be fixed, open a GitHub issue **first** (`gh issue create`), then make the PR that fixes it close that issue automatically with `Fixes #<n>` in the **PR body**.

The notes cover the four things that make it go wrong in practice:

- **Scope is fixes only** - features/chores/docs don't need an issue, and an issue the user already pointed at should be reused rather than duplicated.
- The issue describes the **user-visible symptom**, not the fix - it is the record of the bug.
- The issue **consumes a number from the same sequence as PRs**, which matters because `releases.ts` needs the `pr:` number written before `gh pr create` reports it.
- The closing keyword only auto-closes **from the PR body** (not a title or a later comment), so the close should be verified after merge.

## Release / deployment

Docs-only: **no version bump and no release-notes entry** (per the docs/CI-only carve-out in the checklist). Deployment surface: **neither** a desktop release nor a server redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
