### PR TITLE
docs(omi): target the DevKit 2 (XIAO nRF52840 + 128 GB microSD)

### DIFF
--- a/omi/firmware/docs/02-audio-formats.md
+++ b/omi/firmware/docs/02-audio-formats.md
@@ -196,16 +196,18 @@ for i in range(0, len(stream) - 443, 444):
 
 ## 2.7 The DevKit format is completely different
 
-`devkit/src/storage.c` and `devkit/src/sdcard.c` use a **FAT filesystem** on a removable
+`devkit/src/storage.c` and `devkit/src/sdcard.c` use a **FAT/exFAT filesystem** on a removable
 microSD, with files at `/SD:/audio/aNN.txt` and a file-oriented BLE command set
-(`READ_COMMAND 0`, `DELETE_COMMAND 1`, `NUKE 2`, `STOP_COMMAND 3`). Its on-file frame layout
-is a 3-byte prefix plus an 80-byte padded Opus entry (`FRAME_PREFIX_LENGTH 3`,
-`OPUS_ENTRY_LENGTH 80`), which is what the stale `scripts/devkit/decode_audio.py` parses with
-its hard-coded 83-byte stride.
+(`READ_COMMAND 0`, `DELETE_COMMAND 1`, `NUKE 2`, `STOP_COMMAND 3`).
 
-**None of that applies to the consumer device.** If your hardware is a DevKit, the microSD is
-directly readable on a PC and the retrieval problem is far easier. If it is the consumer CV1,
-it is not.
+Its on-file layout is the **same 440-byte packed block as layer A above, with no timestamp
+header**, and its Opus frames are **10 ms** (160 samples) rather than 20 ms. The 3-byte prefix
+plus 80-byte padded entry that `scripts/devkit/decode_audio.py` assumes is an *older* layout,
+still visible commented out at `devkit/src/transport.c:619-635`; that script is stale for both
+devices.
+
+**None of that applies to the consumer device.** Full DevKit treatment - which is the hardware
+this project actually targets - is in [07-devkit2-target.md](07-devkit2-target.md).
 
 ## 2.8 Data rates and volumes (consumer device)
 

--- a/omi/firmware/docs/05-findings.md
+++ b/omi/firmware/docs/05-findings.md
@@ -193,9 +193,11 @@ commands 0/1/2/3) against the **same** storage service UUIDs the consumer device
 ring protocol (commands 0x10-0x13). A CV1 device will answer every one of those writes with
 `ACK status 6` (invalid command).
 
-`decode_audio.py` parses a fixed 83-byte stride, which is the DevKit's 3-byte prefix plus
-80-byte padded Opus entry - not the consumer device's 444-byte ring packet.
-`get_audio_file.py` also has a hard-coded macOS device UUID.
+`decode_audio.py` parses a fixed 83-byte stride, which matches neither device: it is an
+*older* DevKit layout (3-byte prefix plus 80-byte padded entry), still visible commented out at
+`devkit/src/transport.c:619-635`. The current DevKit writes 440-byte packed blocks and the
+consumer device writes 444-byte ring packets. `get_audio_file.py` also has a hard-coded macOS
+device UUID.
 
 *Implication:* there is **no working reference client for offline retrieval from the consumer
 device in this tree.** One has to be written. The recipe is in

--- a/omi/firmware/docs/06-repurposing-for-diariz.md
+++ b/omi/firmware/docs/06-repurposing-for-diariz.md
@@ -1,5 +1,15 @@
 # 6. Repurposing the device for offline ambient capture into Diariz
 
+> **Superseded for our hardware.** This document was written before the target device was
+> confirmed. We built an **Omi DevKit 2** (XIAO nRF52840 Sense, 128 GB microSD), for which
+> **[07-devkit2-target.md](07-devkit2-target.md) is the authoritative plan**. On that device
+> the removable card can be read directly on a PC, so Option A below (the BLE sync client) is
+> **not needed** and Option C (Wi-Fi) is **not possible** - there is no nRF7002 on a XIAO.
+>
+> Keep this file for the consumer CV1 analysis and for the parts that carry over: the Ogg Opus
+> remux argument in 6.3, the Diariz upload mechanics, and the security changes in 6.4 (B4/B5),
+> which apply to any Omi-derived firmware.
+
 The goal: wear the device, let it record ambiently with no phone involved, then later pull the
 audio off and get it into Diariz as a recording that goes through the normal
 transcribe -> diarize -> summarise pipeline.
@@ -146,28 +156,37 @@ week; Option C is a project.
 
 ## 6.6 If your hardware is a DevKit rather than the consumer device
 
-Check what you actually built. If it is a **Seeed XIAO nRF52840 Sense** based DevKit1/DevKit2
-rather than the nRF5340 consumer board, everything changes for the better:
+**This is our case - confirmed DevKit 2. See [07-devkit2-target.md](07-devkit2-target.md) for
+the full treatment; the sketch below is what prompted it.**
 
-- Storage is a **FAT filesystem on a removable microSD**, at `/SD:/audio/aNN.txt`.
+If it is a **Seeed XIAO nRF52840 Sense** based DevKit1/DevKit2 rather than the nRF5340 consumer
+board, everything changes for the better:
+
+- Storage is a **FAT/exFAT filesystem on a removable microSD**, at `/SD:/audio/aNN.txt`.
 - You can eject the card, read it on a PC, and skip BLE entirely.
-- The frame layout is the DevKit's 3-byte prefix + 80-byte padded Opus entry, and
-  `scripts/devkit/decode_audio.py` is a (crude but working) starting point for decoding it.
 
 In that case Option A collapses to "copy files off the card, decode, upload", and none of F1,
-F2, F4 or the ring protocol applies. Confirm which board you have before writing any client:
-the consumer app advertises as `Omi` and reports DIS model `Omi CV 1`; the DevKit build
-advertises as `Omi DevKit 2`.
+F2, F4 or the ring protocol applies. To tell the boards apart over BLE: the consumer app
+advertises as `Omi` and reports DIS model `Omi CV 1`; the DevKit build advertises as
+`Omi DevKit 2`.
+
+One correction to an earlier assumption: `scripts/devkit/decode_audio.py` is **not** a working
+starting point even for the DevKit. It parses a fixed 83-byte stride (3-byte prefix plus an
+80-byte padded frame), which is the *older* DevKit layout, still visible commented out at
+`devkit/src/transport.c:619-635`. The live DevKit code writes the same 440-byte packed blocks
+as the CV1. Use the decoder in [07-devkit2-target.md](07-devkit2-target.md) section 7.2.
 
 ## 6.7 Suggested order of work
 
-1. Confirm which hardware you built (`Omi` vs `Omi DevKit 2` over BLE, or by the SoC).
-2. Consumer device: **B5 + B4** first if it will be worn outside your home, so you are not
+Superseded by [07-devkit2-target.md](07-devkit2-target.md) section 7.6 now that the target is
+known to be a DevKit 2. Retained for the CV1:
+
+1. Consumer device: **B5 + B4** first if it will be worn outside your home, so you are not
    running an open microphone.
-3. Write the Option A sync client. Prove the decode against a short known recording before
+2. Write the Option A sync client. Prove the decode against a short known recording before
    trusting a long one - the F13 block-boundary guard is the thing most likely to be wrong.
-4. Add **B1** and **B3** to the firmware once you have a build environment working; they are
+3. Add **B1** and **B3** to the firmware once you have a build environment working; they are
    small and they remove the two silent-data-loss paths.
-5. Wire the client's output into `POST /api/recordings` with proper `startedAt`/`endedAt` so
+4. Wire the client's output into `POST /api/recordings` with proper `startedAt`/`endedAt` so
    Diariz timelines line up with reality.
-6. Only then consider Option C.
+5. Only then consider Option C.

--- a/omi/firmware/docs/07-devkit2-target.md
+++ b/omi/firmware/docs/07-devkit2-target.md
@@ -1,0 +1,294 @@
+# 7. DevKit 2 - the target hardware for this project
+
+**Confirmed build: Omi DevKit 2** - a Seeed Studio **XIAO nRF52840 Sense** on the DevKit 2
+carrier board, with a **128 GB microSD card**.
+
+That settles the open question in [06-repurposing-for-diariz.md](06-repurposing-for-diariz.md)
+section 6.6. This document is the DevKit-2-specific review; it supersedes the consumer-device
+(CV1) material wherever the two disagree. Docs 01-05 describe the CV1 unless they say
+otherwise - read them for background, but treat **this** file as authoritative for your device.
+
+Build target: `devkit/`, board `xiao_ble_sense`, preset
+`build_xiao_ble_sense_devkitv2-adafruit`, config
+`prj_xiao_ble_sense_devkitv2-adafruit.conf`, overlay
+`overlay/xiao_ble_sense_devkitv2-adafruit.overlay`.
+
+## 7.1 What changes versus the consumer device
+
+| | Consumer CV1 (docs 01-05) | **DevKit 2 (your device)** |
+|---|---|---|
+| SoC | nRF5340, dual core | **nRF52840**, single core |
+| Storage medium | Soldered 512 MB SD NAND | **Removable microSD, 128 GB** |
+| Storage layout | Raw block ring buffer, no filesystem | **FAT/exFAT filesystem** |
+| Retrieval | BLE ring protocol only | **Eject the card and read it on a PC** |
+| Capacity | ~33 hours | **effectively unlimited - see 7.4** |
+| Files | n/a | A single, ever-growing `/SD:/audio/a01.txt` |
+| Opus frame | 320 samples (20 ms) | **160 samples (10 ms)** |
+| Mic | 2x T5838, stereo mixed to mono | **1x PDM mic, mono** (XIAO Sense onboard) |
+| Silence gating | Hardware AAD, mic sleeps in silence | **None - records continuously** |
+| Wall clock | Per-packet UTC timestamp + BLE time sync | **None at all - see 7.3** |
+| Wi-Fi | nRF7002 populated | **None** |
+| Serial console | UART enabled | **UART disabled in the overlay** |
+| Bootloader | MCUboot, OTA via `dfu_application.zip` | **Adafruit UF2** - drag-and-drop `zephyr.uf2` |
+
+The things that carry over unchanged: Opus at 32 kbps VBR mono 16 kHz, the 440-byte block
+packing (including its parsing artifact), the BLE audio service and its 3-byte notification
+header, and the "any BLE connection suppresses offline recording" hazard.
+
+## 7.2 On-disk format
+
+Simpler than the CV1's, and **missing the timestamp**:
+
+```
+/SD:/audio/a01.txt  =  a concatenation of 440-byte blocks, nothing else
+
+each 440-byte block:
+[len0][opus frame 0][len1][opus frame 1] ... [lenN][opus frame N][padding]
+ 1 B                 1 B                      1 B
+```
+
+There is **no 4-byte header** on a DevKit block - `write_to_file(storage_temp_data, 440)`
+writes the packed block straight to the file. Frames are **10 ms** (160 samples at 16 kHz),
+so a 440-byte block holds roughly 10 frames, about **100 ms** of audio.
+
+The **same block-boundary trap applies** ([05-findings.md](05-findings.md) F13): the overflow
+branch writes the next frame's length byte into the block it is about to flush, so a block can
+end with a length byte that has no data behind it. Guard with
+`if (n == 0 or off + 1 + n > 440) break`.
+
+Decoding is the CV1 recipe minus the header:
+
+```python
+import opuslib
+dec = opuslib.Decoder(16000, 1)
+pcm = bytearray()
+data = open("a01.txt", "rb").read()
+for i in range(0, len(data) - 439, 440):
+    block, off = data[i:i + 440], 0
+    while off < 440:
+        n = block[off]
+        if n == 0 or off + 1 + n > 440:
+            break
+        pcm += dec.decode(bytes(block[off + 1:off + 1 + n]), 160)
+        off += 1 + n
+# pcm is 16 kHz mono signed 16-bit little-endian
+```
+
+Note `scripts/devkit/decode_audio.py` is stale for this firmware too, not just for the CV1: it
+assumes a fixed 83-byte stride (a 3-byte prefix plus an 80-byte padded frame), which is the
+*older* DevKit layout still visible commented out at `devkit/src/transport.c:619-635`. The
+live code writes 440-byte packed blocks. Do not start from that script.
+
+## 7.3 There is no clock. At all.
+
+The DevKit firmware has **no RTC, no time-sync GATT service, and no per-packet timestamps**.
+Nothing in `devkit/src/` references wall-clock time. Zephyr's FatFs also has no RTC hooked up
+(`CONFIG_FS_FATFS_HAS_RTC` is unset), so even the file's modification time is a fixed
+placeholder date rather than when the audio was recorded.
+
+Combined with the fact that the file is opened `FS_O_APPEND` and never truncated or rotated,
+this means:
+
+> `a01.txt` is one unbroken stream of audio spanning every session since the card was last
+> cleared, with no timestamps, no session boundaries, and no gaps marking power-offs.
+
+For Diariz this is the single biggest thing to solve, and it has to be solved **host-side**:
+
+- **Anchor at collection time.** Note when you pull the card, decode the file, measure its
+  duration, and work backwards. Accurate to whenever the device was actually running.
+- **Split on silence.** Because there is no VAD on the device, silence is recorded in full at
+  roughly the same bitrate as speech. Run silence detection over the decoded PCM (ffmpeg
+  `silencedetect`, or an RMS threshold) and cut sessions at long quiet stretches. Feed each
+  segment to Diariz as its own recording with an estimated `startedAt`.
+- **Consider clearing the card each time you sync**, so each card cycle maps to one known
+  window. Simplest reliable approach until the firmware carries a clock.
+
+Adding a timestamp is a small firmware change (a time-sync characteristic plus a 4-byte header
+per block, copying the CV1 design) and is worth doing early - see 7.6.
+
+## 7.4 The 128 GB card
+
+**exFAT is supported.** `prj_xiao_ble_sense_devkitv2-adafruit.conf` sets
+`CONFIG_FS_FATFS_EXFAT=y`, so a 128 GB SDXC card mounts in its factory exFAT format without
+reformatting. (Note FatFs exFAT support is covered by Microsoft patents - fine for personal
+use, worth knowing if this ever ships.)
+
+**Capacity is no longer the constraint.** Without silence gating the device records
+continuously at roughly 4.1 kB/s, about **15 MB/hour** or **355 MB/day**. A 128 GB card
+therefore holds on the order of **a year** of continuous audio. You will hit the battery, the
+file-size limits below, and your own patience long before you fill it.
+
+**Three limits will bite before the card does:**
+
+1. **Battery.** No VAD means the mic, codec and SD writes run 24/7. On a XIAO-class LiPo this
+   is hours, not days. This is now the binding constraint on session length.
+2. **4 GB, if you ever sync over BLE.** The BLE sync path is `uint32` throughout
+   (`file_num_array`, `remaining_length`) and `read_audio_data` takes a **signed int** offset,
+   so it breaks somewhere around 2 GB and certainly at 4 GB. At 15 MB/hour that is about
+   **133 hours** of recording. Irrelevant if you always read the card directly - which you
+   should.
+3. **A single file.** Everything lands in `a01.txt`. `file_count` is computed at mount and then
+   immediately overwritten with a hard-coded `1` (`devkit/src/sdcard.c:101`), and
+   `generate_new_audio_header()` caps at `a99.txt` anyway. There is no rotation.
+
+**Data-loss hazard: the firmware can reformat your card.** `CONFIG_FS_FATFS_MOUNT_MKFS=y` is
+set and `mount_point.flags` is left at 0, so `FS_MOUNT_FLAG_NO_FORMAT` is *not* applied. If
+`fs_mount` fails because FatFs does not recognise the filesystem, Zephyr will **format the
+card**. A card that Windows wrote in a layout FatFs dislikes, or a card with a partition scheme
+it cannot parse, gets wiped on the next boot. Two mitigations, both cheap:
+
+- Always copy `a01.txt` off the card before putting it back in the device.
+- Set `mount_point.flags = FS_MOUNT_FLAG_NO_FORMAT;` in `mount_sd_card()` and rebuild. Then a
+  mount failure is a mount failure rather than a wipe.
+
+## 7.5 DevKit-specific findings
+
+Numbered `D*` to keep them distinct from the CV1 findings in
+[05-findings.md](05-findings.md).
+
+### D1 - Use-after-free in `initialize_audio_file()`. **Medium**
+
+`devkit/src/sdcard.c`:
+
+```c
+char *header = generate_new_audio_header(num);
+if (header == NULL) return -1;
+k_free(header);
+create_file(header);      /* <-- header was just freed */
+```
+
+The pointer is freed and then dereferenced. It happens to work today because `k_free` does not
+scrub the block and nothing reallocates in between, but it is undefined behaviour and it is on
+the boot path. Fix by moving `k_free` after `create_file`.
+
+### D2 - `file_count` is computed and then discarded. **Low**
+
+`sdcard.c:100-101` calls `get_file_contents()` to count files, then unconditionally assigns
+`file_count = 1;`. The directory scan is dead work, and any pre-existing `a02.txt`+ are
+invisible to the firmware. `initialize_audio_file(1)` is also called twice on the mount path.
+
+### D3 - The storage size gate compares the wrong variable. **Low**
+
+`transport.c:731` gates offline writes on `file_num_array[1] < MAX_STORAGE_BYTES`
+(`0xFFFF0000`, about 4.29 GB). But `update_file_size()` puts the **file size** in
+`file_num_array[0]` and the **sync read offset** in `file_num_array[1]`. So the gate tests the
+read offset, never the size, and never fires. In practice there is no size cap at all.
+
+### D4 - `file_num_array` is 2 entries but indexed by file number. **Low**
+
+`sdcard.c:34` declares `uint32_t file_num_array[2]`, and `storage.c:145` and `:190` index it as
+`file_num_array[current_read_num - 1]` / `[file_num - 1]` where the index comes from the BLE
+command byte. Any file number above 2 reads out of bounds. Unreachable today only because
+`file_count` is pinned to 1 (D2), which rejects `file_num > file_count` first.
+
+### D5 - The file is opened and closed on every 440-byte write. **Medium**
+
+`write_to_file()` does `fs_open(FS_O_WRITE|FS_O_APPEND)` / `fs_write` / `fs_close` per block,
+i.e. roughly **ten times a second**, and checks none of the three return values. That is a FAT
+metadata update per block: unnecessary wear, unnecessary power, and a much larger window for
+power-loss corruption than keeping the handle open with a periodic `fs_sync` would give.
+
+On the other hand it does mean the file length on disk is always current, so an unexpected
+power cut loses at most one block.
+
+### D6 - Same "connected suppresses recording" hazard, different mechanism. **High**
+
+The CV1 loses audio when a central is connected but not subscribed
+([05-findings.md](05-findings.md) F2). The DevKit gets there by a different route:
+`transport.c:403` sets `storage_is_on = true` on **connect**, and the pusher only writes to
+storage `if (!valid && !storage_is_on)`. So while any BLE connection exists, offline recording
+is off - and if that connection has not subscribed to the audio characteristic, nothing is
+streamed either. Audio is dropped.
+
+Same operational rule applies: keep centrals away from the device while it is recording, or
+patch the condition.
+
+### D7 - Frame length is stored in one byte but can exceed 255. **Low, latent**
+
+`CODEC_OUTPUT_MAX_BYTES` is `160 * 2 = 320` on the DevKit, while the storage framing writes the
+length into a single byte (`storage_temp_data[buffer_offset] = tx_buffer_size`). A frame above
+255 bytes would be silently truncated and would desynchronise the decoder for the rest of the
+block. At 32 kbps with 10 ms frames the typical size is about 40 bytes, so this needs a
+pathological VBR excursion to trigger - but it is not structurally prevented.
+
+### D8 - No serial console by default. **Low, but it will cost you time**
+
+The v2 overlay sets `&uart0 { status = "disabled"; }`, and `usb.c` only registers a
+charge-detect callback - there is no CDC-ACM console. Debugging means re-enabling UART (see the
+DevKit 2 section of `firmware/readme.md` for the exact `CONFIG_*` lines) and, per that same
+note, disabling `CONFIG_OMI_ENABLE_OFFLINE_STORAGE` or raising the log thread priority, because
+logging and SD writes interfere.
+
+### D9 - `CONFIG_I2C=n` with `CONFIG_LSM6DSL=y`. **Low**
+
+Same conflict as the CV1 ([05-findings.md](05-findings.md) F7): `prj_...devkitv2-adafruit.conf`
+disables I2C while enabling the IMU driver, and the overlay puts the LSM6DS3TR-C on `i2c0`.
+The IMU is unused by this application, so unlike the CV1 (where it backs the clock recovery)
+nothing depends on it.
+
+### D10 - Overlay comment contradicts the code. **Cosmetic**
+
+`cs-gpios = <&gpio0 2 GPIO_ACTIVE_LOW>;  // CS pin on P0.28` - the code says P0.02, the comment
+says P0.28. Worth resolving against your actual wiring before debugging any SD problem.
+
+## 7.6 Revised plan for getting audio into Diariz
+
+The DevKit changes the plan substantially, and mostly for the better. **Option A from
+[06-repurposing-for-diariz.md](06-repurposing-for-diariz.md) - the BLE sync client - is no
+longer needed.** Neither is F1 (no clock gate on writes), F4 (no destructive sync), or the ring
+protocol.
+
+**Phase 1 - card-swap workflow, no firmware change at all.**
+
+1. Record. Eject the card. Note the wall-clock time you ejected it.
+2. Copy `a01.txt` off the card **before** reinserting it (protects against the auto-format
+   hazard in 7.4).
+3. Decode with the snippet in 7.2 to 16 kHz mono PCM.
+4. Split into sessions with silence detection, and derive each session's `startedAt` by working
+   backwards from the ejection time.
+5. Encode each session as **Ogg Opus** (remux the existing frames, no re-encode - about
+   15 MB/hour) or WAV, and `POST /api/recordings` with `source=Upload`, `startedAt`, `endedAt`
+   and a title. Diariz transcribes, diarizes and summarises from there.
+6. Delete `a01.txt` from the card so the next cycle starts clean.
+
+That is a host-side script and nothing else. It is the fastest route to real transcripts and it
+is where I would start.
+
+**Phase 2 - the firmware changes worth making, in order.**
+
+- **D-fix-1: add a clock.** Port the CV1's time-sync service (`19B10030`/`19B10031`) and its
+  4-byte big-endian per-block timestamp. This removes the guesswork from step 4 above and is
+  the single highest-value change. Copy `omi/src/rtc.c` and the header write in
+  `process_write_data_req`; the format is documented in
+  [02-audio-formats.md](02-audio-formats.md) section 2.5.
+- **D-fix-2: `FS_MOUNT_FLAG_NO_FORMAT`.** One line. Stops the firmware wiping a card it cannot
+  read.
+- **D-fix-3: rotate files.** Close `a01.txt` and start `a02.txt` on a size or time boundary.
+  Gives natural session boundaries and keeps every file under the 2 GB signed-offset limit.
+  Needs D2 and D4 fixed first so the file table is real.
+- **D-fix-4: fix D6** so a stray BLE connection cannot silently stop recording.
+- **D-fix-5: add silence gating.** The nRF52840 has no T5838 AAD to lean on, but a software
+  amplitude gate in the mic callback (the CV1's `CONFIG_OMI_VAD_*` knobs are the model) would
+  cut both battery draw and the amount of dead air the host has to split out. Biggest win for
+  battery life.
+- **D-fix-6: fix D1 and D5** - the use-after-free, and keeping the file handle open with a
+  periodic `fs_sync` instead of open/close per block.
+
+**Not applicable to this device:** the Wi-Fi upload path (Option C) - there is no nRF7002 on a
+XIAO nRF52840. If direct upload ever matters more than the card-swap workflow, that is an
+argument for building the consumer board, not for modifying this one.
+
+## 7.7 Flashing
+
+The DevKit 2 uses the **Adafruit UF2 bootloader**, not MCUboot. Double-tap reset to mount the
+`XIAO-SENSE` drive, then copy `build/zephyr/zephyr.uf2` onto it - which is exactly what
+`devkit/flash.sh` does:
+
+```bash
+west build && cp build/zephyr/zephyr.uf2 /Volumes/XIAO-SENSE/
+```
+
+`bootloader/bootloader0.9.0.uf2` and the files under `bootloader/deprecated/` are the XIAO
+bootloader images, kept for recovery. None of the MCUboot signing, `dfu_application.zip`, or
+J-Link material in `BUILD_AND_OTA_FLASH.md` and `FLASH_3.0.8/` applies to your device - that is
+all CV1.

--- a/omi/firmware/docs/README.md
+++ b/omi/firmware/docs/README.md
@@ -16,6 +16,22 @@ Nothing in this folder changes the firmware. It is analysis only.
 | [04-offline-storage.md](04-offline-storage.md) | The raw SD ring buffer, capacity and timing maths, sync behaviour |
 | [05-findings.md](05-findings.md) | Bugs, hazards, dead code, config conflicts and security posture found during review |
 | [06-repurposing-for-diariz.md](06-repurposing-for-diariz.md) | Options for offline capture -> Diariz upload, ranked by effort |
+| [07-devkit2-target.md](07-devkit2-target.md) | **The device we actually built.** DevKit 2 specifics, and the plan as revised for it |
+
+## Which device this project targets
+
+**Omi DevKit 2** - a Seeed Studio XIAO nRF52840 Sense with a 128 GB microSD card.
+
+Docs 01-06 were written before that was confirmed and describe the **consumer CV1** (nRF5340)
+unless they say otherwise. They remain accurate for the CV1 and are worth reading for
+background - the audio pipeline, Opus settings, 440-byte block packing and BLE audio service
+are shared - but where the two devices differ,
+**[07-devkit2-target.md](07-devkit2-target.md) is authoritative**.
+
+The headline differences: the DevKit stores to a **removable, FAT/exFAT-formatted card you can
+read directly on a PC** rather than a raw block-level ring buffer, which removes the need for a
+BLE sync client entirely. In exchange it has **no clock of any kind** and **no silence gating**,
+so it produces one endless untimestamped file that has to be split host-side.
 
 ## One paragraph summary
 


### PR DESCRIPTION
## What

The device we built is an **Omi DevKit 2** - Seeed Studio XIAO nRF52840 Sense with a **128 GB microSD card** - not the consumer CV1. Adds `omi/firmware/docs/07-devkit2-target.md` as the authoritative plan for that hardware, and re-points docs 02/05/06/README, which were written before the target was confirmed.

## Release checklist

**`omi/` only - excluded from the release checklist** per the rule added in #611. No version bump, no `RELEASES` entry, no `CAPABILITIES` / About-box / README / `features.md` / synopsis / schema / help-article changes.

## Deployment surface

**Neither.** Docs only, inside the vendored side-project tree.

## Why this needed its own document

The DevKit shares file names with the CV1 but diverges more than that suggests:

| | Consumer CV1 (docs 01-05) | DevKit 2 (our device) |
|---|---|---|
| Storage | Raw block ring on soldered 512 MB NAND | **Removable 128 GB microSD, FAT/exFAT** |
| Retrieval | BLE ring protocol only | **Eject the card, read it on a PC** |
| Opus frame | 320 samples (20 ms) | **160 samples (10 ms)** |
| Mic | 2x T5838, stereo mixed | **1x PDM, mono** |
| Silence gating | Hardware AAD | **None - records continuously** |
| Wall clock | Per-packet UTC + BLE time sync | **None at all** |
| Wi-Fi | nRF7002 populated | **None** |
| Bootloader | MCUboot / OTA zip | **Adafruit UF2 drag-and-drop** |

This is mostly good news: **the BLE sync client is no longer needed**, and findings F1 (clock gate on writes), F4 (destructive sync) and the whole ring protocol drop away. Capacity stops being a constraint too - ~15 MB/hour against 128 GB is roughly a year of continuous audio, so battery is now the binding limit.

The cost is that there is **no clock anywhere in the DevKit firmware** - no RTC, no time-sync service, no per-packet timestamp, and FatFs has no RTC hooked up so even the file mtime is a placeholder. The file is opened `FS_O_APPEND` and never rotated, so `a01.txt` is one unbroken stream across every session since the card was last cleared. Splitting it into Diariz recordings has to happen host-side via silence detection, anchored to the time the card was pulled.

## New findings (D1-D10)

Worth calling out three:

- **D1** - use-after-free on the boot path: `initialize_audio_file()` calls `k_free(header)` and then `create_file(header)`.
- **D3** - the offline-write size gate tests `file_num_array[1]`, which holds the sync *read offset*, not the file size (that is `[0]`). The cap never fires; there is effectively no size limit.
- **7.4** - `CONFIG_FS_FATFS_MOUNT_MKFS=y` with `mount_point.flags` left at 0 means **the firmware will format a card FatFs fails to recognise**. One-line fix (`FS_MOUNT_FLAG_NO_FORMAT`), and until then: always copy the file off before reinserting the card.

Also **D6** - the DevKit has the same "a BLE connection suppresses offline recording" hazard as the CV1 (F2), reached differently: `storage_is_on = true` on connect gates the storage branch.

## Correction to the earlier docs

Docs 02, 05 and 06 described `scripts/devkit/decode_audio.py` as a crude but working starting point for DevKit files. **It is not.** Its 83-byte stride is an *older* layout, still visible commented out at `devkit/src/transport.c:619-635`. The current DevKit writes the same 440-byte packed blocks as the CV1, minus the 4-byte timestamp header - so one decoder serves both devices. Corrected in all three files; a working snippet is in 07 section 7.2.

## Suggested next step

Phase 1 in section 7.6 needs **no firmware change at all**: eject card, copy `a01.txt`, decode, split on silence, upload each session to `POST /api/recordings` as Ogg Opus with an estimated `startedAt`. That is a host-side script and the fastest route to real transcripts. Phase 2 lists the firmware fixes in priority order, with "add a clock" first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
