### PR TITLE
feat(omi): stop the DevKit reformatting cards, add a build runbook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -474,3 +474,12 @@ apps/desktop/native/**/obj/
 # directory (ARMv4/v5 assembly + headers). The Visual Studio `[Aa][Rr][Mm]/`
 # build-output rule above would otherwise swallow them and break the build.
 !omi/**/arm/
+
+# Omi firmware builds. The build scripts create the nRF Connect SDK west workspace
+# in-tree (omi/firmware/v2.7.0 for the DevKit, v2.9.0 for the CV1) - about 1.5 GB - and
+# CV1 builds generate prj.conf by copying omi.conf. None of it belongs in the repo.
+# See omi/firmware/docs/08-build-and-flash-runbook.md.
+omi/firmware/v2.*/
+omi/firmware/build/
+omi/firmware/*/build/
+omi/firmware/*/prj.conf

--- a/omi/firmware/devkit/prj_xiao_ble_sense_devkitv1-spisd.conf
+++ b/omi/firmware/devkit/prj_xiao_ble_sense_devkitv1-spisd.conf
@@ -102,7 +102,11 @@ CONFIG_OMI_OFFLINE_STORAGE=y
 CONFIG_DISK_ACCESS=y
 CONFIG_FILE_SYSTEM=y
 CONFIG_FAT_FILESYSTEM_ELM=y
-CONFIG_FS_FATFS_MOUNT_MKFS=y
+# Never auto-format the card. The mount also sets FS_MOUNT_FLAG_NO_FORMAT (sdcard.c),
+# which already blocks it; disabling mkfs here drops the dead code and makes the intent
+# a build-level guarantee. The PC owns formatting and deleting - see
+# omi/firmware/docs/08-build-and-flash-runbook.md.
+CONFIG_FS_FATFS_MOUNT_MKFS=n
 CONFIG_FS_FATFS_EXFAT=y
 CONFIG_PRINTK=y
 CONFIG_MAIN_STACK_SIZE=5096

--- a/omi/firmware/devkit/prj_xiao_ble_sense_devkitv2-adafruit.conf
+++ b/omi/firmware/devkit/prj_xiao_ble_sense_devkitv2-adafruit.conf
@@ -144,7 +144,11 @@ CONFIG_PRINTK=n
 CONFIG_DISK_ACCESS=y
 CONFIG_FILE_SYSTEM=y
 CONFIG_FAT_FILESYSTEM_ELM=y
-CONFIG_FS_FATFS_MOUNT_MKFS=y
+# Never auto-format the card. The mount also sets FS_MOUNT_FLAG_NO_FORMAT (sdcard.c),
+# which already blocks it; disabling mkfs here drops the dead code and makes the intent
+# a build-level guarantee. The PC owns formatting and deleting - see
+# omi/firmware/docs/08-build-and-flash-runbook.md.
+CONFIG_FS_FATFS_MOUNT_MKFS=n
 CONFIG_FS_FATFS_EXFAT=y
 #nessessary?
 CONFIG_MAIN_STACK_SIZE=2048

--- a/omi/firmware/devkit/src/main.c
+++ b/omi/firmware/devkit/src/main.c
@@ -228,6 +228,17 @@ int main(void)
     err = mount_sd_card();
     if (err) {
         LOG_ERR("Failed to mount SD card (err %d)", err);
+        /* This build ships with CONFIG_CONSOLE=n, so the log above goes nowhere and the
+         * device would just appear dead. Since the firmware no longer formats a card it
+         * cannot read (see FS_MOUNT_FLAG_NO_FORMAT in sdcard.c), an unformatted card is
+         * now a realistic way to get here - so say so. Six slow red blinks = "the card
+         * is the problem"; format it on a PC as exFAT or FAT32 and re-insert it. */
+        for (int i = 0; i < 6; i++) {
+            set_led_red(true);
+            k_msleep(400);
+            set_led_red(false);
+            k_msleep(400);
+        }
         return err;
     }
     k_msleep(500);

--- a/omi/firmware/devkit/src/sdcard.c
+++ b/omi/firmware/devkit/src/sdcard.c
@@ -15,9 +15,24 @@ LOG_MODULE_REGISTER(sdcard, CONFIG_LOG_DEFAULT_LEVEL);
 
 static FATFS fat_fs;
 
+/*
+ * FS_MOUNT_FLAG_NO_FORMAT is deliberate and load-bearing.
+ *
+ * Without it, and with CONFIG_FS_FATFS_MOUNT_MKFS enabled, Zephyr responds to
+ * FR_NO_FILESYSTEM by running f_mkfs() - so a card this firmware cannot parse gets
+ * reformatted the moment it is re-inserted, destroying every recording on it. FatFs is
+ * fussier than a PC about partition layouts, so "cannot parse" is not the same as
+ * "blank", and the failure was silent (this build has CONFIG_CONSOLE=n).
+ *
+ * The device is now strictly a reader/appender of a card the PC owns. Formatting and
+ * deleting are done on the PC, where they are deliberate acts with a filesystem the OS
+ * already understands. An unformatted or unreadable card fails the mount instead, which
+ * main.c signals on the LED.
+ */
 static struct fs_mount_t mount_point = {
     .type = FS_FATFS,
     .fs_data = &fat_fs,
+    .flags = FS_MOUNT_FLAG_NO_FORMAT,
 };
 
 struct gpio_dt_spec sd_en_gpio_pin = {.port = DEVICE_DT_GET(DT_NODELABEL(gpio0)),
@@ -71,7 +86,11 @@ int mount_sd_card(void)
     if (res == FR_OK) {
         LOG_INF("SD card mounted successfully");
     } else {
-        LOG_ERR("f_mount failed: %d", res);
+        /* We never format: see the FS_MOUNT_FLAG_NO_FORMAT note above. Format the card
+         * on a PC (exFAT or FAT32) and re-insert it. */
+        LOG_ERR("fs_mount failed: %d - card not formatted or not readable. "
+                "Format it on a PC; this firmware will not do it for you.",
+                res);
         return -1;
     }
 

--- a/omi/firmware/docs/07-devkit2-target.md
+++ b/omi/firmware/docs/07-devkit2-target.md
@@ -131,15 +131,25 @@ file-size limits below, and your own patience long before you fill it.
    immediately overwritten with a hard-coded `1` (`devkit/src/sdcard.c:101`), and
    `generate_new_audio_header()` caps at `a99.txt` anyway. There is no rotation.
 
-**Data-loss hazard: the firmware can reformat your card.** `CONFIG_FS_FATFS_MOUNT_MKFS=y` is
-set and `mount_point.flags` is left at 0, so `FS_MOUNT_FLAG_NO_FORMAT` is *not* applied. If
-`fs_mount` fails because FatFs does not recognise the filesystem, Zephyr will **format the
-card**. A card that Windows wrote in a layout FatFs dislikes, or a card with a partition scheme
-it cannot parse, gets wiped on the next boot. Two mitigations, both cheap:
+**Data-loss hazard: the firmware could reformat your card. FIXED - rebuild required.**
+As shipped upstream, `CONFIG_FS_FATFS_MOUNT_MKFS=y` was set and `mount_point.flags` was left
+at 0, so `FS_MOUNT_FLAG_NO_FORMAT` was *not* applied. If `fs_mount` failed because FatFs did
+not recognise the filesystem, Zephyr ran `f_mkfs()` and **formatted the card**. A card that
+Windows wrote in a layout FatFs dislikes, or one with a partition scheme it cannot parse, was
+wiped on the next boot - silently, because this build has `CONFIG_CONSOLE=n`.
 
-- Always copy `a01.txt` off the card before putting it back in the device.
-- Set `mount_point.flags = FS_MOUNT_FLAG_NO_FORMAT;` in `mount_sd_card()` and rebuild. Then a
-  mount failure is a mount failure rather than a wipe.
+Our tree now sets `FS_MOUNT_FLAG_NO_FORMAT` in `mount_sd_card()` and
+`CONFIG_FS_FATFS_MOUNT_MKFS=n` in the DevKit configs. The PC owns formatting and deleting;
+the device only reads and appends. An unreadable card now fails the mount and `main.c` blinks
+red six times instead of wiping it.
+
+Two things follow:
+
+- **The fix only exists in firmware you build and flash yourself.** A device still running a
+  stock upstream image has the old behaviour, so keep copying `a01.txt` off the card before
+  reinserting it until you have flashed your own build.
+- **A blank card no longer self-provisions.** Format it on the PC as exFAT or FAT32 first -
+  see [08-build-and-flash-runbook.md](08-build-and-flash-runbook.md) section 8.4.
 
 ## 7.5 DevKit-specific findings
 
@@ -274,8 +284,9 @@ keeps the tool free of any native Opus dependency while still emitting a lossles
   the single highest-value change. Copy `omi/src/rtc.c` and the header write in
   `process_write_data_req`; the format is documented in
   [02-audio-formats.md](02-audio-formats.md) section 2.5.
-- **D-fix-2: `FS_MOUNT_FLAG_NO_FORMAT`.** One line. Stops the firmware wiping a card it cannot
-  read.
+- **D-fix-2: `FS_MOUNT_FLAG_NO_FORMAT`. DONE.** Stops the firmware wiping a card it cannot
+  read; `main.c` now blinks red six times instead. Needs a rebuild and reflash to take
+  effect - see [08-build-and-flash-runbook.md](08-build-and-flash-runbook.md).
 - **D-fix-3: rotate files.** Close `a01.txt` and start `a02.txt` on a size or time boundary.
   Gives natural session boundaries and keeps every file under the 2 GB signed-offset limit.
   Needs D2 and D4 fixed first so the file table is real.

--- a/omi/firmware/docs/08-build-and-flash-runbook.md
+++ b/omi/firmware/docs/08-build-and-flash-runbook.md
@@ -1,0 +1,278 @@
+# 8. Build and flash runbook (DevKit 2)
+
+Everything needed to go from a clean Windows machine to modified firmware running on the
+device. Written for the **Omi DevKit 2** - Seeed Studio XIAO nRF52840 Sense - which is the
+hardware this project targets ([07-devkit2-target.md](07-devkit2-target.md)). The consumer
+CV1 is different in almost every respect; see section 8.10.
+
+> **Not yet executed.** This runbook was written by reading the build scripts, board
+> definitions and configs in this tree, not by running them - there is no nRF Connect SDK
+> toolchain on the machine it was written on. The commands are transcribed from
+> `scripts/build-docker.sh`, `scripts/build-firmware-in-docker.sh` and
+> `devkit/CMakePresets.json`, so they should be right, but treat the first run as a
+> shakedown and correct this file as you go. Known-uncertain points are marked **[unverified]**.
+
+---
+
+## 8.1 What you are building
+
+| | |
+|---|---|
+| Application | `omi/firmware/devkit` |
+| Board | `xiao_ble/nrf52840/sense` |
+| SDK | nRF Connect SDK **v2.7.0** (the CV1 uses 2.9.0 - do not mix them up) |
+| Config | `devkit/prj_xiao_ble_sense_devkitv2-adafruit.conf` |
+| Overlay | `devkit/overlay/xiao_ble_sense_devkitv2-adafruit.overlay` |
+| Bootloader | Adafruit UF2 (**not** MCUboot) |
+| Primary output | `zephyr.uf2` - drag-and-drop onto the device |
+
+---
+
+## 8.2 Route A: Docker (recommended)
+
+One prerequisite, no toolchain on your machine, and the same result on any OS. The build
+scripts are already in the tree and already point at the DevKit 2 config.
+
+### Install
+
+1. **[Docker Desktop](https://www.docker.com/products/docker-desktop/)** with the WSL2
+   backend. Start it and wait for the whale icon to settle before building.
+2. **Git Bash** (ships with Git for Windows). The build scripts are bash; PowerShell will
+   not run them.
+
+That is the whole list. The container brings its own Zephyr SDK, west, CMake and Ninja.
+
+### Build
+
+From anywhere in the repo, in **Git Bash**:
+
+```bash
+MSYS_NO_PATHCONV=1 ./omi/firmware/scripts/build-docker.sh
+```
+
+`MSYS_NO_PATHCONV=1` matters on Windows: without it Git Bash rewrites the container-side
+`/omi` mount target into a Windows path and the build fails with confusing "no such file"
+errors from inside the container.
+
+First run downloads the container image and then ~1.5 GB of nRF Connect SDK sources into
+`omi/firmware/v2.7.0/`. Budget 20-40 minutes and a good connection. Later runs reuse both
+and take a few minutes.
+
+To start completely fresh (deletes the in-tree SDK and build directories):
+
+```bash
+MSYS_NO_PATHCONV=1 ./omi/firmware/scripts/build-docker.sh --clean
+```
+
+### Where the output lands
+
+```
+omi/firmware/build/docker_build/
+  zephyr.uf2   <- flash this (section 8.5)
+  zephyr.hex   <- for a debugger / nrfjprog
+  zephyr.bin   <- raw image
+  zephyr.zip   <- OTA package for the Adafruit bootloader (section 8.6)
+```
+
+All of it is gitignored, along with `omi/firmware/v2.7.0/`. Nothing from a build should
+ever appear in `git status`; if it does, the ignore rules need extending.
+
+### Windows gotchas **[unverified]**
+
+* **`the input device is not a TTY`** - the script runs `docker run --rm -it`. If your
+  terminal refuses, prefix with `winpty`, or edit the script to drop `-it`.
+* **Slow builds / file-permission oddities** - the bind mount crosses the Windows/WSL2
+  boundary. If it is painful, clone the repo inside the WSL2 filesystem and build there.
+* **Unpinned image.** `build-docker.sh` pulls `ghcr.io/zephyrproject-rtos/ci` with no tag,
+  so it silently follows `latest`. A future image could ship a Zephyr SDK that no longer
+  matches NCS 2.7.0. If a build that worked last month stops working and nothing in the
+  tree changed, this is the first suspect - pin a tag in the script.
+
+---
+
+## 8.3 Route B: nRF Connect for VS Code (native)
+
+Use this when you want a debugger, live logs, or the IDE's Kconfig browser. It is more
+setup, and it is the route the upstream project documents.
+
+### Install
+
+1. **[nRF Command Line Tools](https://www.nordicsemi.com/Products/Development-tools/nrf-command-line-tools)**
+2. **[VS Code](https://code.visualstudio.com/)** + the **nRF Connect for VS Code Extension Pack**
+3. In the extension's **Toolchain Manager**, install **nRF Connect SDK v2.7.0** and its
+   matching toolchain.
+4. **Python 3** on PATH, then `pip install adafruit-nrfutil` if you want to build OTA packages.
+
+### Build
+
+1. Open the **`omi/firmware`** folder in VS Code - **not** the repo root, and not
+   `omi/firmware/devkit`. West only recognises the project and finds the board definitions
+   from `omi/firmware`.
+2. nRF Connect panel -> **Add build configuration**.
+3. Pick the preset **`build_xiao_ble_sense_devkitv2-adafruit`** from
+   `devkit/CMakePresets.json`. It sets the config file and overlay for you.
+4. **Build**. Output appears under
+   `devkit/build/build_xiao_ble_sense_devkitv2-adafruit/zephyr/`.
+
+**Board-name discrepancy [unverified].** The CMake preset sets `BOARD=xiao_ble_sense`
+(the pre-hardware-model-v2 name) while the Docker script uses `xiao_ble/nrf52840/sense`
+(the NCS 2.7 name). If the preset fails to resolve a board, change it to
+`xiao_ble/nrf52840/sense` - that is the spelling known to work in the container.
+
+---
+
+## 8.4 Prepare the card before first boot
+
+**This changed, and it is the reason this runbook exists.** The firmware no longer formats
+a card it cannot read. It used to: `CONFIG_FS_FATFS_MOUNT_MKFS` was enabled and the mount
+did not set `FS_MOUNT_FLAG_NO_FORMAT`, so re-inserting a card FatFs disliked wiped every
+recording on it, silently. The PC now owns formatting and deleting.
+
+So, once per card:
+
+1. Format it on the PC as **exFAT** (the factory format for a 128 GB SDXC card, and what
+   `CONFIG_FS_FATFS_EXFAT=y` supports) or **FAT32**.
+2. Insert it and power on.
+
+If the card is unformatted, unreadable, or absent, the device now **blinks red six times
+and stops** rather than booting into a state where it records nothing. That signal is the
+only feedback you get, because this build ships with `CONFIG_CONSOLE=n`.
+
+Routine cycle after that: pull the card, copy `a01.txt` off it, delete `a01.txt` **from the
+PC**, re-insert. See [`omi/tools/omi-sync`](../../tools/omi-sync/README.md).
+
+---
+
+## 8.5 Flash over USB (UF2)
+
+The DevKit uses the **Adafruit UF2 bootloader**, so flashing is a file copy. No debugger,
+no J-Link, no driver.
+
+1. Connect the XIAO over USB-C.
+2. **Double-tap the reset button.** A removable drive named **`XIAO-SENSE`** appears.
+3. Copy `zephyr.uf2` onto it.
+4. The drive dismounts by itself and the device reboots into the new firmware.
+
+If the drive does not appear, the double-tap was too slow or too fast - try again with a
+brisk double-click rhythm. A cable that is charge-only will also do this; try another.
+
+On macOS `devkit/flash.sh` automates step 3 (it copies to `/Volumes/XIAO-SENSE`). There is
+no Windows equivalent in the tree; drag-and-drop or `cp`.
+
+---
+
+## 8.6 Flash over the air (optional)
+
+`build-firmware-in-docker.sh` also produces `zephyr.zip` via:
+
+```bash
+adafruit-nrfutil dfu genpkg --dev-type 0x0052 --dev-revision 0xCE68 \
+    --application zephyr.hex zephyr.zip
+```
+
+That package is for the **Adafruit nRF52 bootloader's** DFU, which is a different mechanism
+from the CV1's MCUboot OTA. **[unverified]** - the UF2 route is simpler, needs no app, and
+is what this runbook recommends. Reach for OTA only if you have a reason to.
+
+---
+
+## 8.7 Recovering a bricked bootloader
+
+If the `XIAO-SENSE` drive stops appearing entirely, the bootloader itself may be damaged.
+`omi/firmware/bootloader/` holds the images:
+
+* `bootloader0.9.0.uf2` - the current bootloader, flashable over UF2 if the old one still
+  enumerates.
+* `deprecated/*.hex` - full images needing a debugger (J-Link or an nRF DK acting as one).
+
+**[unverified]** - not something to try casually.
+
+---
+
+## 8.8 Getting logs out
+
+The shipped DevKit 2 config is **silent**: `CONFIG_CONSOLE=n`, `CONFIG_PRINTK=n`, `CONFIG_LOG`
+commented out, and the v2 overlay disables `uart0` outright. Every `LOG_INF`/`LOG_ERR` in
+the firmware goes nowhere.
+
+To get logs back, in `devkit/prj_xiao_ble_sense_devkitv2-adafruit.conf`:
+
+```
+CONFIG_CONSOLE=y
+CONFIG_PRINTK=y
+CONFIG_LOG=y
+CONFIG_LOG_PRINTK=y
+CONFIG_UART_CONSOLE=y
+```
+
+and, per `firmware/readme.md`, either disable offline storage while debugging:
+
+```
+CONFIG_OMI_ENABLE_OFFLINE_STORAGE=n
+```
+
+or keep it and drop the log thread's priority so logging does not fight SD writes:
+
+```
+CONFIG_LOG_PROCESS_THREAD_PRIORITY=5
+CONFIG_LOG_PROCESS_THREAD_CUSTOM_PRIORITY=y
+```
+
+**You will also have to re-enable the UART**, which `firmware/readme.md` does not mention:
+the v2 overlay contains `&uart0 { status = "disabled"; };`. Remove or comment that block,
+or the console has no device to attach to. **[unverified]** - this contradiction between
+the overlay and the documented debug steps has not been resolved on hardware. If serial
+still gives nothing after both changes, USB CDC-ACM is the fallback, and it is not
+configured in this tree either.
+
+Then use the **nRF Serial Terminal** in VS Code, or any terminal at 115200 baud.
+
+---
+
+## 8.9 Verify the change actually landed
+
+Firmware failures here are quiet, so check positively rather than assuming:
+
+1. **It boots** - the boot LED sequence runs (red, green, blue, white).
+2. **The card mounts** - no six-blink red pattern.
+3. **It records** - leave it running somewhere noisy for a few minutes, power down, pull the
+   card, and confirm `/SD:/audio/a01.txt` has grown.
+4. **The audio is real** - run it through `omi-sync` and listen:
+
+   ```bash
+   cd omi/tools/omi-sync
+   python -m omi_sync /path/to/a01.txt --dry-run --out ./out
+   ffprobe -hide_banner ./out/omi-*.opus
+   ```
+
+   `ffprobe` should report opus, 1 channel, 48000 Hz.
+5. **The no-format change works** - the deliberate test is to insert a card the firmware
+   cannot read (an unformatted one, or one with an ext4 partition) and confirm you get the
+   six red blinks and the card comes back **unchanged** on the PC. Do this with a scratch
+   card, obviously.
+
+---
+
+## 8.10 The consumer CV1, for contrast
+
+Do not follow this runbook for a CV1. It uses nRF Connect SDK **2.9.0**, board
+`omi/nrf5340/cpuapp`, sysbuild with MCUboot, and produces `dfu_application.zip` /
+`merged.hex` / `merged_CPUNET.hex` rather than a UF2. `scripts/ci/build-cv1.sh` is the
+authoritative build, and `BUILD_AND_OTA_FLASH.md` covers OTA. Note that script references
+`omi/firmware/omi/BUILD.md`, which does not exist ([05-findings.md](05-findings.md) F14).
+
+---
+
+## 8.11 Troubleshooting
+
+| Symptom | Likely cause |
+|---|---|
+| `no such file or directory` from inside the container | Missing `MSYS_NO_PATHCONV=1` on Windows |
+| `the input device is not a TTY` | `docker run -it` under a non-TTY terminal; use `winpty` or drop `-it` |
+| `west update` fails or hangs | Network, or a half-initialised workspace: `--clean` and retry |
+| `No board named 'xiao_ble_sense'` | Board renamed in NCS 2.7; use `xiao_ble/nrf52840/sense` |
+| Build succeeds, no `zephyr.uf2` | UF2 output is board-driven; check the build log for `CONFIG_BUILD_OUTPUT_UF2` |
+| `XIAO-SENSE` drive never appears | Double-tap rhythm, or a charge-only USB cable |
+| Device boots, six red blinks | The card is unformatted or unreadable - format it on the PC (8.4) |
+| Device records nothing, no blinks | Something is holding a BLE connection open (finding D6), or the card is full |
+| `git status` full of build files | The ignore rules in `.gitignore` need extending |

--- a/omi/firmware/docs/README.md
+++ b/omi/firmware/docs/README.md
@@ -17,6 +17,7 @@ Nothing in this folder changes the firmware. It is analysis only.
 | [05-findings.md](05-findings.md) | Bugs, hazards, dead code, config conflicts and security posture found during review |
 | [06-repurposing-for-diariz.md](06-repurposing-for-diariz.md) | Options for offline capture -> Diariz upload, ranked by effort |
 | [07-devkit2-target.md](07-devkit2-target.md) | **The device we actually built.** DevKit 2 specifics, and the plan as revised for it |
+| [08-build-and-flash-runbook.md](08-build-and-flash-runbook.md) | **How to build and flash it.** Prerequisites, Docker and VS Code routes, UF2 flashing, logging, troubleshooting |
 
 ## Tools
 

--- a/omi/tools/omi-sync/README.md
+++ b/omi/tools/omi-sync/README.md
@@ -49,9 +49,13 @@ pip install pytest mutagen
 
 ## Use
 
-**Copy `a01.txt` off the card before you put the card back in the device.** The firmware
-has `CONFIG_FS_FATFS_MOUNT_MKFS=y` with no `FS_MOUNT_FLAG_NO_FORMAT`, so a card it fails
-to mount gets reformatted (docs 07 section 7.4).
+**Copy `a01.txt` off the card before you put the card back in the device** - unless you are
+running firmware built from this tree. Upstream firmware auto-formats a card it fails to
+mount (docs 07 section 7.4); our tree sets `FS_MOUNT_FLAG_NO_FORMAT` and disables
+`CONFIG_FS_FATFS_MOUNT_MKFS` so it never does. That fix only exists in a build you flash
+yourself - see [the build runbook](../../firmware/docs/08-build-and-flash-runbook.md).
+
+Either way the PC owns deletion: delete `a01.txt` yourself after a successful sync.
 
 Look before you upload:
 


### PR DESCRIPTION
## 1. The device no longer formats a card it cannot read

Upstream set `CONFIG_FS_FATFS_MOUNT_MKFS=y` and left `mount_point.flags` at 0, so Zephyr answered `FR_NO_FILESYSTEM` by running `f_mkfs()`. Re-inserting a card FatFs disliked **wiped every recording on it**. FatFs is fussier than a PC about partition layouts, so "cannot parse" is not the same as "blank" - and the failure was silent, because this build ships `CONFIG_CONSOLE=n`.

The device is now strictly a reader/appender of a card the PC owns. Formatting and deleting happen on the PC, deliberately, with a filesystem the OS already understands.

Fixed in two places:

- **`FS_MOUNT_FLAG_NO_FORMAT` on the mount** (`devkit/src/sdcard.c`) - the actual fix. `mount_sd_card()` is shared, so this covers every DevKit variant.
- **`CONFIG_FS_FATFS_MOUNT_MKFS=n`** in the two configs that set it - drops the now-dead code and makes the intent a build-level guarantee rather than something a future edit to the flags can quietly undo.

### One thing I added that you did not ask for

A blank card no longer self-provisions, and with logging compiled out a failed mount would have looked like a dead device. So `main.c` now **blinks red six times** before giving up. Trading silent data loss for a silent brick would not have been an improvement, and it is six lines. Say the word if you would rather it kept booting without storage so live BLE streaming still works - that is a bigger behaviour change, which is why I did not make it.

### Checked, not assumed

I traced every deletion path in the DevKit firmware before touching anything. `clear_audio_file` / `clear_audio_directory` / `NUKE` are all reached **only** from BLE commands in `storage.c`, never automatically. `create_file()` opens with `FS_O_WRITE | FS_O_CREATE` and no truncate, so `a01.txt` genuinely survives re-insertion. The auto-format at mount was the only thing that deleted audio on its own.

## 2. `docs/08-build-and-flash-runbook.md`

Clean machine to modified firmware on the device:

- Prerequisites for both routes - **Docker** (recommended: one install, NCS 2.7.0, `xiao_ble/nrf52840/sense`) and **nRF Connect for VS Code**.
- Windows specifics, including the `MSYS_NO_PATHCONV=1` bind-mount trap that would otherwise fail with confusing errors from inside the container.
- UF2 flashing (double-tap reset -> `XIAO-SENSE` drive), OTA, and bootloader recovery.
- **How to prepare a card now that the firmware will not** (section 8.4).
- How to get logs out of a build that ships silent - including that the v2 overlay disables `uart0`, which `firmware/readme.md`'s debug instructions do not mention and which will otherwise waste an afternoon.
- Verification steps and a troubleshooting table.

Also `.gitignore`: the build scripts create the west workspace **in-tree** at `omi/firmware/v2.7.0` (~1.5 GB), and CV1 builds generate `prj.conf`. Anyone following the runbook would otherwise flood `git status`.

## Not built, not flashed

**Neither change has been compiled.** There is no nRF Connect SDK toolchain on this machine, so the C is reviewed-by-reading only. The firmware tree also has no test harness, so this is production code with no failing test in front of it - **flagging for sign-off per CLAUDE.md's TDD rule**.

The runbook is transcribed from the build scripts rather than from a run that happened; uncertain points are marked **[unverified]** in the text. Treat your first build as a shakedown and correct the file as you go.

Section 8.9 has the deliberate test for this change: insert a scratch card the firmware cannot read, confirm six red blinks, and confirm the card comes back **unchanged** on the PC.

## Release checklist

**`omi/` only - excluded from the release checklist** per the rule added in #611. No version bump, no `RELEASES` entry, no About-box / README / `features.md` / synopsis / schema / help-article changes.

## Deployment surface

**Neither** a desktop release nor a server redeploy - nothing here is part of any Diariz deployable. It does need a **firmware rebuild and reflash** to reach the device, which is what the runbook is for.

## Docs kept in step

`07-devkit2-target.md` sections 7.4 and 7.6 (D-fix-2 now marked DONE), the docs index, and the `omi-sync` README - which previously told you to copy `a01.txt` off the card because of this exact hazard, and now explains that the fix only exists in firmware you build yourself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
