### PR TITLE
Fix link and typo in README.md for Runtime Architecture

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ See [diariz.app](https://www.diariz.app) for more details, videos and screenshot
 [docs/Overall_Synopsis_of_Platform.md](docs/Overall_Synopsis_of_Platform.md) has the original brief and the
 architecture plan for the full design.
 
+[docs/Runtime_Aechitcture.html](https://htmlpreview.github.io/?https://github.com/kenhayward/Diariz/blob/main/docs/Runtime_Architecture.html) has a live visual navigation of how Diariz fits together.
+
 Versioned per the rule in [CLAUDE.md](CLAUDE.md); the current version and per-release notes live in
 [`apps/web/src/lib/releases.ts`](apps/web/src/lib/releases.ts) (and [`/version.json`](version.json)) and on
 the in-app **Release Notes** page (`/release-notes`), reachable from **About** in the account menu.
@@ -66,7 +68,7 @@ See **[docs/features.md](docs/features.md)** for the full prose description of e
 
 ## Architecture
 
-For a visual navigation of the architecure see **[docs/Runtime_Architecture.html](docs/Runtime_Architecture.html)**
+[docs/Runtime_Aechitcture.html](https://htmlpreview.github.io/?https://github.com/kenhayward/Diariz/blob/main/docs/Runtime_Architecture.html) has a live visual navigation of how Diariz fits together.
 
 | Component | Tech | Path |
 | :--- | :--- | :--- |


### PR DESCRIPTION
Corrected the link to the Runtime Architecture documentation and fixed a typo in the heading.