### PR TITLE
Give findBy/waitFor the timeout the config already intended

### DIFF
--- a/apps/web/src/test-setup.test.ts
+++ b/apps/web/src/test-setup.test.ts
@@ -1,0 +1,19 @@
+import { getConfig } from "@testing-library/dom";
+import { describe, expect, it } from "vitest";
+
+/// What the shared setup actually put in place, asserted rather than assumed.
+///
+/// `setupFiles` runs per test file and nothing else checks it took effect, so a line silently removed - or
+/// a later import resetting the value - would go unnoticed until something flaked.
+describe("test setup", () => {
+  it("gives findBy/waitFor a budget matched to this suite, not the 1s default", () => {
+    // `testTimeout` in vitest.config.ts was raised to 20s specifically because the default flaked under
+    // contention. That setting does not govern testing-library's async utilities: `findBy*` and `waitFor`
+    // use their own `asyncUtilTimeout`, which defaults to 1000ms - so the fix left the assertions that
+    // actually wait on the old budget. Everything here that awaits an element awaits it through those.
+    //
+    // Kept below `testTimeout` on purpose: a missing element then fails as "unable to find an element",
+    // naming what it looked for, instead of an opaque test timeout.
+    expect(getConfig().asyncUtilTimeout).toBe(5000);
+  });
+});

--- a/apps/web/src/test-setup.ts
+++ b/apps/web/src/test-setup.ts
@@ -13,6 +13,21 @@ import i18n from "./lib/i18n";
 
 i18n.changeLanguage("en");
 
+// Give testing-library's async utilities the same budget vitest.config.ts already gives a test.
+//
+// `testTimeout` was raised to 20s there because the default flaked under contention - but it does not
+// govern `findBy*` or `waitFor`, which have their own `asyncUtilTimeout` and were left on 1000ms. Almost
+// every wait in this suite goes through those, so the fix did not reach the assertions it was written for.
+//
+// Deliberately well below `testTimeout`: exceeding this reports "unable to find an element" and names what
+// it looked for, which is a far better failure than an opaque test timeout.
+// From @testing-library/dom, which owns this setting, rather than the react wrapper that re-exports
+// it: setup runs for every test file, and pulling React and react-dom/test-utils into the 122 that
+// never render cost ~30s of the suite's CPU when this was first written that way.
+import { configure } from "@testing-library/dom";
+
+configure({ asyncUtilTimeout: 5000 });
+
 // jsdom doesn't implement Element.scrollIntoView; components that scroll to a segment (RecordingDetail's
 // transcript deep-link) call it in an effect, which otherwise throws an unhandled error and fails the run.
 if (!Element.prototype.scrollIntoView) {

--- a/apps/web/vitest.config.ts
+++ b/apps/web/vitest.config.ts
@@ -20,9 +20,13 @@ export default defineConfig({
     globals: true, // enables @testing-library/react's automatic cleanup between tests
     setupFiles: ["./src/test-setup.ts"], // initialise i18next once for component tests
     include: ["src/**/*.test.ts", "src/**/*.test.tsx"],
-    // The self-hosted CI runner is resource-constrained (the full suite takes ~60s there vs ~8s locally),
-    // so the 5s default per-test timeout flakes under contention. Raise the ceiling well above any real
-    // render time; a genuine hang still fails, just later.
+    // CI is resource-constrained next to a dev machine, so the 5s default per-test timeout flakes under
+    // contention. Raise the ceiling well above any real render time; a genuine hang still fails, just
+    // later.
+    //
+    // This governs the test, not the waiting inside it: `findBy*` and `waitFor` use testing-library's own
+    // `asyncUtilTimeout`, which is set alongside it in src/test-setup.ts. Raising one without the other
+    // leaves every assertion that actually waits on the 1s default, which is how this was for a long time.
     testTimeout: 20000,
     hookTimeout: 20000,
   },


### PR DESCRIPTION
## The flake

`SettingsModal > opens the usage panel without leaving the modal` failed twice in one session, both times on a full-suite run, and passed on immediate re-run and in isolation.

**I could not reproduce it.** Twenty-plus full runs, including six back-to-back, several under deliberate CPU contention (a full `dotnet build --no-incremental` and a second vitest run in parallel), and one with the Vite cache deleted. All green. So what follows is the most likely explanation, not a proven one - stated plainly because the difference matters.

### What the investigation did establish

`vitest.config.ts` raises `testTimeout` to 20s, with a comment saying the 5s default "flakes under contention". **That setting does not govern the waiting inside a test.** `findBy*` and `waitFor` use testing-library's own `asyncUtilTimeout`, which nothing here configured, so it sat on its **1000ms** default.

Almost every wait in this suite goes through those helpers. So the fix that was applied for timeout flakiness never reached the assertions that actually wait - a 20x budget for the test, 1x for everything inside it.

The failing assertion awaits a `React.lazy` panel (`LlmUsage`). Measured in isolation it resolves in **103ms** - roughly a 10x margin against 1000ms, which is precisely the size of slowdown the config's own comment describes on a constrained runner.

### What changed

`asyncUtilTimeout: 5000` in `src/test-setup.ts`. Five times the margin, and deliberately **below** `testTimeout` so a genuinely missing element still fails as "unable to find an element", naming what it looked for, instead of an opaque test timeout.

Imported from `@testing-library/dom` (which owns the setting) rather than the react wrapper, because setup runs for every file and 122 of them never render.

`src/test-setup.test.ts` asserts the effective config. `setupFiles` running is not checked anywhere, so a line removed later - or reset by a later import - would go unnoticed until something flaked again. Mutation-verified: deleting the `configure` call fails it.

**If the flake recurs it will now fail with a message worth reading**, which is the other half of the value here.

## Why the suite feels slow

Measured, since the summary numbers are easy to misread - they are **summed across parallel workers**, not elapsed:

| | value |
|---|---|
| Wall clock, full suite | **~27s** for 3,299 tests across 280 files |
| `environment` (jsdom construction) | ~265s summed - **the single largest cost** |
| `tests` (the assertions themselves) | ~138s summed |

So the suite as a whole is not slow. What is slow is **per-file fixed overhead**: a single test file costs roughly 1s before any assertion runs (jsdom ~400ms, setup ~290ms, transform ~270ms). Running one file to check one test is therefore ~90% overhead.

The slowest files, for reference: `RecordingDetail` 13.2s/90 tests, `Recorder` 11.2s/114, `SettingsModal` 7.4s/38.

### The lever, measured but not pulled

`src/lib` is **122 files and 1,269 tests**. Those tests take **2.29s**. Constructing jsdom for them takes **121s** - about 53x more time building a DOM than using one.

I tested moving the DOM-free ones to `environment: "node"`. One line in `test-setup.ts` blocks it (`Element.prototype.scrollIntoView`, unguarded). With that guarded, **80 of 87 candidate files pass under node** and their `environment` cost falls from **79.6s to 7ms**.

I have **not** made that change here. It touches every one of those files, the 7 failures show a grep cannot reliably tell which need a DOM, and it deserves its own PR rather than riding along with a timeout fix. Happy to do it if you want it.

## Testing

3,299 web tests green (280 files). The .NET suites are untouched by this change.

**Measured A/B**, two full runs each, because a change to shared setup that slowed the suite down would be a poor trade in a PR about the suite being slow:

| | wall clock | setup | import |
|---|---|---|---|
| Without | 27.84s / 27.07s | 54.8 / 54.3 | 62.2 / 62.6 |
| With | 27.44s / 27.39s | 76.6 / 77.6 | 47.4 / 47.5 |

**No wall-clock cost.** The rise in the reported `setup` phase is offset by an equal fall in `import` - the same module load, attributed to a different phase.

(My first attempt at this comparison was invalid: the `git stash` silently failed on a path error and both sides measured the same tree. The table above is from a redone A/B where the baseline runs report 3,298 tests and the change runs 3,299.)

## Deployment

**Neither.** Test configuration only - nothing ships to a server or a desktop build.

## Release checklist

- **No version bump and no `RELEASES` entry.** Test-only, like a CI-only PR: nothing user-facing changed, and a release note about a test timeout is noise in the About box. Flagging the judgement call - say the word and I will add a Build bump.
- No `CAPABILITIES` / README / `docs/features.md` / help change: no capability changed
- No `docs/Overall_Synopsis_of_Platform.md` or `docs/Data_Schema.md` change: no architecture, contract or schema change
- No OpenAPI or n8n regeneration: no endpoint change
- Corrected a stale comment in `vitest.config.ts` while there: it described a self-hosted CI runner, and CI is GitHub-hosted now

🤖 Generated with [Claude Code](https://claude.com/claude-code)
