### PR TITLE
chore: mark EF migration snapshots as generated, and record the size review

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -18,3 +18,15 @@
 # psql tolerates CRLF, but keep these LF for the same reason as the shell scripts above -
 # so what a fresh Windows clone mounts is byte-identical to what CI and Linux hosts mount.
 deploy/postgres-init/*.sql text eol=lf
+
+# EF Core writes a full copy of the model into a *.Designer.cs alongside every migration.
+# At 98 migrations that is ~215,000 lines - 96% of src/Diariz.Domain/Migrations, and 94% of
+# the compiled Diariz.Domain.dll (2,988 KB with them, 175 KB without). None of it is written
+# or read by hand: `dotnet ef migrations add` generates it and EF consumes it.
+#
+# Marking it generated collapses it in GitHub diffs and drops it from the language stats, so a
+# one-column migration reviews as its ~20 real lines instead of a 3,600-line wall. Deliberately
+# NOT `-diff`, which would also suppress the local `git diff` you want on the rare occasion a
+# snapshot change is the thing you are actually inspecting.
+src/Diariz.Domain/Migrations/*.Designer.cs linguist-generated=true
+src/Diariz.Domain/Migrations/DiarizDbContextModelSnapshot.cs linguist-generated=true

--- a/docs/Data_Schema.md
+++ b/docs/Data_Schema.md
@@ -20,6 +20,8 @@ details both stores. For how it all fits together see [`Overall_Synopsis_of_Plat
 - **Migrations** live in `src/Diariz.Domain/Migrations`. The API **auto-applies migrations on startup**
   (`Program.cs`) and seeds the default user, roles, the `PlatformSettings` singleton, and ensures the MinIO
   bucket — you do not run `database update` by hand for normal dev.
+  For why that folder is 225,000 lines and the one condition under which squashing it is worth doing,
+  see [`EF_Migrations_Size_Review.md`](EF_Migrations_Size_Review.md).
 - **pgvector is Postgres-only.** The `vector` extension and the `vector(n)` columns are mapped **only when
   `Database.IsNpgsql()`**; under the EF in-memory provider (unit tests) those properties are `Ignore`d. Keep
   any new Postgres-only model config behind the same guard.

--- a/docs/EF_Migrations_Size_Review.md
+++ b/docs/EF_Migrations_Size_Review.md
@@ -1,0 +1,159 @@
+# EF Core Migrations - Size, Cost, and When to Squash
+
+A record of what `src/Diariz.Domain/Migrations` actually weighs, what that costs, and the one
+condition under which squashing it becomes worth doing. Written so the question does not have to be
+re-derived from scratch next time someone notices the folder is enormous.
+
+Measured 30 August 2026 at version 0.262.0, commit `a769a28e`. See
+[Re-measuring](#re-measuring) at the end - every figure here is reproducible in a few minutes.
+
+---
+
+## Summary
+
+The folder is **225,137 lines**, and **95.6% of it is machine-written**. It costs about **1.5 seconds
+of an 11.6 second clean solution build** and **nothing at runtime**. The only cost that genuinely bit
+was **review** - a one-column migration opened as a 3,600-line diff - and that was fixed in PR #681 by
+marking the generated files `linguist-generated` in `.gitattributes`.
+
+**Do not squash on its own.** It would make every existing backup unrestorable. There is a specific
+future PR in which squashing costs nothing; wait for it.
+
+---
+
+## 1. What is actually in the folder
+
+EF Core writes a complete copy of the model into a `*.Designer.cs` beside every migration. That file,
+not the schema changes, is what dominates.
+
+| Content | Lines | Share |
+|---|---:|---:|
+| Model snapshots (`*.Designer.cs`) | 215,222 | 95.6% |
+| Actual `Up()` / `Down()` logic | 6,318 | 2.8% |
+| `DiarizDbContextModelSnapshot.cs` | 3,597 | 1.6% |
+| **Total** | **225,137** | 8.6 MB on disk |
+
+98 migrations, `InitialCreate` (15 Jun 2026) through `AddActionPinned` (28 Aug 2026). Sixteen of them
+do real data work via `migrationBuilder.Sql`.
+
+**Two things that look wrong and are not:**
+
+- The folder holds **107 non-Designer `.cs` files but only 98 migrations**. The extra eight are
+  hand-written backfill helpers (`PersonalRoomBackfill.cs`, `RoleToGroupBackfill.cs` and friends).
+  They correctly carry no `[Migration]` attribute, so EF never discovers them as migrations.
+- **The database agrees exactly:** `__EFMigrationsHistory` holds 98 rows, first `InitialCreate`, last
+  `AddActionPinned`. Nothing has drifted.
+
+## 2. Growth is superlinear
+
+Each snapshot is a copy of the *current* model, so its size grows as the model grows. Total folder
+size is therefore roughly `migrations x model size` - it bends upward rather than climbing steadily.
+
+| Month | Migrations | Lines added | Per migration | Cumulative |
+|---|---:|---:|---:|---:|
+| Jun 2026 | 22 | 17,752 | 807 | 17,752 |
+| Jul 2026 | 44 | 89,735 | 2,039 | 107,487 |
+| Aug 2026 | 32 | 107,735 | 3,367 | 215,222 |
+
+August added **more lines than July from fewer migrations**. A single migration cost 513 lines at
+`InitialCreate` and costs about 3,600 today.
+
+At the observed cadence of ~40 migrations/month, six more months adds roughly **1.8 million lines**.
+That figure is an extrapolation, not a measurement - it is the reason to keep a plan, not a reason to
+act this week.
+
+## 3. What it costs today
+
+Every figure below came from running the thing. The build comparison was made by temporarily adding
+`<Compile Remove="Migrations/**" />` to `Diariz.Domain.csproj` and rebuilding.
+
+| Where | Cost | Verdict |
+|---|---|---|
+| Domain assembly | 2,988 KB with migrations, **175 KB** without | 94% of the DLL |
+| Clean build, Domain | 2.0-3.4 s with, ~1.0 s without | ~1.5 s |
+| Clean build, whole solution | 11.6 s total | Migrations are ~10% |
+| Deployed image | 2.85 MB inside a 488 MB `/app` | Noise |
+| Runtime | `No migrations were applied` - one history query, reflection over 98 types | Not measurable |
+| CodeQL | ~5 min end to end, four languages in parallel | Not dominated by this |
+
+The cost that actually bites is none of these: it is **review**. That is what PR #681 addressed.
+
+## 4. Why we are not squashing
+
+Squashing is the obvious fix and it is blocked by something concrete. This is the part that is not
+visible from the Migrations folder itself, which is why it is written down here.
+
+`MaintenanceController.EvaluateCompatibility` (`src/Diariz.Api/Controllers/MaintenanceController.cs:206`)
+decides whether a platform backup can be restored by looking its `MigrationId` up in the
+**compile-time** migration list:
+
+```csharp
+// MaintenanceController.EvaluateCompatibility
+int idxBackup = list.IndexOf(manifest.MigrationId);
+if (idxBackup < 0)
+    return (false, false, $"This backup's schema version ... is not recognised by this build.");
+```
+
+Squash and every historical id disappears from that list, so **every backup taken so far fails to
+restore**. Per `CLAUDE.md` that forces a `MaintenanceController.CurrentFormat` bump, which then
+rejects all pre-squash backups deliberately and permanently.
+
+There is no clever way around it. Even keeping a static list of retired ids purely for ordering would
+not help: a squashed assembly has no migrations left that can roll a two-month-old schema forward to
+current, so the restore genuinely cannot complete.
+
+So the trade on offer today is: give up the ability to restore any backup from the platform's first
+two and a half months, in exchange for ~1.5 s of build time and 2.85 MB of a 488 MB image. Clear no.
+
+### The trigger that changes the answer
+
+The expensive half of a squash is the `CurrentFormat` bump, not the squash. So **squash inside
+whatever future PR is bumping `CurrentFormat` anyway** - a destructive column drop or rename, a
+pgvector dimension change, any semantic reshape an older dump cannot survive. At that point the
+backups are already being invalidated for another reason and the marginal cost of squashing is zero.
+
+That PR should also delete the corresponding entry from the deferred-work list.
+
+## 5. Considered and rejected
+
+- **A compiled model** (`dotnet ef dbcontext optimize`). It targets model *building* at startup, not
+  migration bloat, and would add a second generated corpus to keep in sync for perhaps 200 ms once per
+  process. Not worth it.
+- **Dropping the Designer files from compilation.** They carry the `[Migration]` attribute, and EF
+  needs each migration's target model to generate SQL when applying it. They are not optional - the
+  `<Compile Remove>` experiment above is a measurement technique, not a shippable change.
+- **`-diff` in `.gitattributes`** alongside `linguist-generated`. It would also suppress the local
+  `git diff` you want on the rare occasion a snapshot change is the thing under review.
+
+## 6. Re-measuring
+
+Run these from the repository root when you want to know whether the picture has changed.
+
+**Size the folder and the split:**
+
+```bash
+cd src/Diariz.Domain/Migrations && ls *.Designer.cs | wc -l && cat *.cs | wc -l && cat *.Designer.cs | wc -l
+```
+
+**Weigh the assembly.** Add `<Compile Remove="Migrations/**" />` to `Diariz.Domain.csproj`, rebuild,
+compare the DLL size and build time, then revert the csproj. The build succeeds without them - nothing
+in `DiarizDbContext` references a migration.
+
+**Check the database agrees.** The count should match the file count; a mismatch means drift, which is
+a different and more urgent problem than size.
+
+```bash
+docker exec diariz-postgres-1 psql -U diariz -d diariz -c 'select count(*) from "__EFMigrationsHistory";'
+```
+
+**Confirm the runtime cost is still nil.** Look for `No migrations were applied`. If migrations *are*
+being applied on every boot, something is wrong with the history table, not with the folder.
+
+```bash
+docker logs diariz-api-1 2>&1 | grep -i migrat
+```
+
+---
+
+Build timings are Debug configuration on the development machine and will differ on CI. The line
+counts, assembly sizes and database figures are exact.


### PR DESCRIPTION
## What

Two commits, both about the same thing:

1. **`.gitattributes`** - marks `src/Diariz.Domain/Migrations/*.Designer.cs` and
   `DiarizDbContextModelSnapshot.cs` as `linguist-generated=true`.
2. **`docs/EF_Migrations_Size_Review.md`** - the analysis behind that change, and the condition under
   which the bigger fix (squashing) becomes worth doing. Cross-linked from the migrations section of
   `docs/Data_Schema.md`.

## Why

EF Core writes a full copy of the model into a `*.Designer.cs` beside every migration. Measured on this
branch:

| | Lines | Share of the Migrations folder |
|---|---:|---:|
| Actual `Up()`/`Down()` logic | 6,318 | 2.8% |
| `*.Designer.cs` model snapshots | 215,222 | **95.6%** |
| `DiarizDbContextModelSnapshot.cs` | 3,597 | 1.6% |

98 migrations, 15 Jun - 28 Aug. Each one now carries ~3,600 lines of snapshot, up from 513 at
`InitialCreate`, and none of it is written or read by hand. The practical cost is review: a one-column
migration currently opens as a 3,600-line diff, so the ~20 lines that matter are buried.

Marking the files generated collapses them in GitHub's diff view and drops them from the repository
language stats. Deliberately **not** `-diff`, which would also suppress the local `git diff` you want on
the rare occasion a snapshot change is the thing you are actually inspecting.

## Verification

`git check-attr` resolves the attribute to exactly the intended set - the generated files, and nothing
else:

```
Migrations/20260828185823_AddActionPinned.Designer.cs: linguist-generated: true
Migrations/DiarizDbContextModelSnapshot.cs:            linguist-generated: true
Migrations/20260828185823_AddActionPinned.cs:          linguist-generated: unspecified
DiarizDbContext.cs:                                    linguist-generated: unspecified
```

The real migration code stays fully reviewable; only the generated snapshots collapse.

## What this does not do

It does not shrink anything - the lines and the 2,988 KB `Diariz.Domain.dll` are unchanged. Squashing
would shrink them, and the doc records why we are not doing it yet:
`EvaluateCompatibility` (`src/Diariz.Api/Controllers/MaintenanceController.cs:206`) resolves a backup's
`MigrationId` against the compile-time migration list, so removing historical ids makes every existing
backup fail as *"not recognised by this build"*, which per CLAUDE.md forces a `CurrentFormat` bump that
permanently rejects all pre-squash backups. The measured saving would be ~1.5 s of an 11.6 s clean
solution build and 2.85 MB of a 488 MB image, which does not buy that.

The trigger is written down instead: squash inside whatever future PR is bumping `CurrentFormat`
anyway, where the marginal cost is zero. Also added to the deferred-work list.

## Release checklist

No version bump and no `RELEASES` entry: this is repository tooling plus an internal reference doc, with
no shipped or user-visible effect, so it takes the docs/CI-only carve-out. Flagging the judgement call in
case you would rather it carried a build bump.

Items 4-7: nothing about the app's behaviour, schema, architecture or feature set changes, so the README
Features table, `docs/features.md` and `Overall_Synopsis_of_Platform.md` are untouched and still accurate.
`docs/Data_Schema.md` gains a two-line pointer to the new doc from its existing migrations section - no
schema claim in it changes.

Per CLAUDE.md's TDD rule the `.gitattributes` change is the "pure config" exception: no test accompanies
it. A test asserting that `.gitattributes` contains a given line would restate the file rather than verify
behaviour; the `git check-attr` output above is the real check, and it is quoted rather than automated.

## Deployment surface

**Neither** a desktop release nor a server redeploy - nothing is built from or shipped with either file.

## Related

Not closing anything. Separately opened #680 for an EF model-validation warning noticed during the same
audit (a missing sentinel silently discards a user's first "Ungrouped" placement choice); it is unrelated
to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
