### PR TITLE
docs: spec streaming capture and the live transcript

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -30,3 +30,9 @@ deploy/postgres-init/*.sql text eol=lf
 # snapshot change is the thing you are actually inspecting.
 src/Diariz.Domain/Migrations/*.Designer.cs linguist-generated=true
 src/Diariz.Domain/Migrations/DiarizDbContextModelSnapshot.cs linguist-generated=true
+
+# tools/transcription-bench/chunk_floor.py is bind-mounted into the Linux worker container and
+# run there. Python 3 reads CRLF source fine, so nothing breaks today - this is the same
+# precaution as the shell scripts above: keep what a Windows clone mounts byte-identical to what
+# a Linux host mounts, so a future shebang or `sh -c` wrapper does not fail only on a fresh clone.
+tools/transcription-bench/*.py text eol=lf

--- a/docs/Overall_Synopsis_of_Platform.md
+++ b/docs/Overall_Synopsis_of_Platform.md
@@ -3131,6 +3131,16 @@ diarization and embeddings all on the GPU, at 95-98% GPU utilisation. Indicative
 ~1.3-1.7x realtime for `large-v3`, untuned. Note that Strix Halo is an APU with a *dynamic* unified-memory
 carve-out, so a point-in-time "VRAM %" reading is not a headroom figure — the allocation grows on demand.
 
+**That 1.3-1.7x figure is ROCm-only and must not be used to reason about the CUDA deployment.** It is the
+`openai-whisper` (pure PyTorch, unbatched) backend on an APU. The CUDA path — faster-whisper/CTranslate2,
+`float16`, batch 16 — measured **~49x realtime (median)** on an RTX 5090 across 58 real recordings totalling
+73.5 h, worst observed ~21x; so an hour of audio is roughly **75 seconds** of worker time there, not 37-46
+minutes. Short clips are dominated by a fixed **~1.26 s** per-job floor (a 30 s clip costs ~2.7 s), of which
+**75-80% is pyannote diarization** — ASR is about a quarter, alignment and ECAPA are rounding errors. The
+same measurement found an 8 GB card (RTX 4070 Laptop) unable to sustain realtime at all: 95% VRAM, crossing
+1.0x at ~150 s and settling at 1.06x. Method, full ladder and caveats:
+`docs/Streaming_Capture_and_Live_Transcript.md` §3 and §16.
+
 **Both obvious tuning levers measured as dead ends**, and the noise floor is the reason to be sceptical of
 any further micro-tuning: repeated runs of the same 269 s file span **123-200 s (±25%)**. Against that,
 `HSA_OVERRIDE_GFX_VERSION=11.0.0` was within noise on warm runs and **2.3x slower cold** (MIOpen rebuilding

--- a/docs/Streaming_Capture_and_Live_Transcript.md
+++ b/docs/Streaming_Capture_and_Live_Transcript.md
@@ -591,24 +591,34 @@ bullet and the About-box `CAPABILITIES` row in lockstep. PR 1 and PR 2 both touc
 
 ## 16. Appendix - measurement method
 
-Reproducible without any production data.
+The harness is checked in at **`tools/transcription-bench/`** with its own README; what follows is
+the method and the caveats that belong with the numbers in §3. Reproducible without any production
+data.
 
 **Test audio.** A synthetic two-speaker "meeting" generated with Windows TTS (two English voices,
-varied speaking rate, invented content), rendered to 16 kHz mono 16-bit WAV, then sliced with Python's
-stdlib `wave` module into a contiguous ladder of 5, 10, 15, 20, 30, 45, 60, 90, 120, 180 and 240 s
-clips from a common 2 s offset. Only the length varies across the ladder.
+varied speaking rate, invented content) by `make-audio.ps1`, rendered to 16 kHz mono 16-bit WAV, then
+sliced by `slice.py` with Python's stdlib `wave` module into a contiguous ladder of 5, 10, 15, 20, 30,
+45, 60, 90, 120, 180 and 240 s clips from a common 2 s offset. Only the length varies across the ladder.
+Benchmark material is synthesised rather than sampled precisely so it can never be production audio.
 
 **Two harnesses:**
 
-- *In-container, per-stage.* Replicates `pipeline.transcribe()` stage by stage with a timer around each
-  call, run inside the worker image with the models warm. Must apply `rocm_env.clean_gfx_override()` and
+- *In-container, per-stage* (`chunk_floor.py`, driven by `run-local.ps1`). Replicates
+  `pipeline.transcribe()` stage by stage with a timer around each call, run inside the worker image with
+  the models warm. Must apply `rocm_env.clean_gfx_override()` and
   `torch_compat.restore_legacy_torch_load()` before importing `pipeline` - `worker.py` does this and a
   script that imports `pipeline` directly does not, so the pyannote VAD checkpoint fails to load on
-  torch >= 2.6 without it.
-- *Via the REST API, end-to-end.* Uploads each clip, polls until transcribed, and reads
+  torch >= 2.6 without it. Touches no queue and writes nothing back.
+- *Via the REST API, end-to-end* (`api_floor.py`). Uploads each clip, polls until transcribed, and reads
   `RecordingDetailDto.Current.ProcessingMs` (note: the field is `current`, not `transcription`). Needs
   only a `dz_api_` token, so it works against any instance without shell access. It reports queue wait
   separately from processing time so contention is visible rather than silently inflating results.
+
+**Supporting tools.** `speakers.py` confirms diarization actually ran on both boxes rather than being
+silently skipped - without which a cross-box timing comparison is meaningless, since diarization is
+75-80% of the cost. `validate.py` produced §3.2 and is the only tool in the set that reads production
+data; it emits counts, ratios and percentiles only. `cleanup.py` removes whatever an interrupted run
+left behind.
 
 **Hygiene.** Benchmark recordings are titled `floor-bench <n>s`. Cleanup matches on `Recording.Title`,
 never `Name` - the summariser overwrites `Name` and would defeat a name-based filter, while `Title` is
@@ -623,3 +633,9 @@ afterwards and the instance was verified back to its prior count.
   audio is cheaper, not dearer.
 - Each API-route upload also triggers the owner's summary/actions/tags jobs, so a re-run spends LLM
   calls. Use the in-container harness where that matters.
+- **A straight-line fit is not always valid.** Both harnesses fit `total = floor + slope * seconds`,
+  which holds only where the curve has no regime change. The 4070 ladder steps at 20 s, and fitting
+  one line across that step returns a *negative* intercept - an artefact, not a floor. Both tools now
+  say so when the intercept comes out below zero. Prefer a measured row over the fit generally: the
+  fit is least accurate mid-ladder, which is exactly where the live chunk sizes are (it predicts 2.1 s
+  for a 30 s clip on the 5090 against 2.67 s measured).

--- a/docs/Streaming_Capture_and_Live_Transcript.md
+++ b/docs/Streaming_Capture_and_Live_Transcript.md
@@ -1,0 +1,625 @@
+# Streaming Capture and Live Transcript - Feature Specification
+
+**Status:** specified, gated on one spike (§5.1). Throughput question **measured and closed** (§3).
+**Surface:** web recorder (`apps/web`), API (`src/Diariz.Api`), worker (`src/Diariz.Worker`), domain (`src/Diariz.Domain`)
+**Server changes:** yes - new entity, new status, new Redis stream, new endpoints, new callback
+**Desktop release:** not required (the shell is untouched; the recorder lives in the web app)
+
+---
+
+## 1. What the user asked for
+
+> "Uploading the transcript in chunks or even streamed to the server - i.e. at some interval during
+> the meeting, creating the recording record as the record button is pressed and then updating it as
+> the meeting progresses. Reasoning being I would like in future to have the transcript and chat
+> function available to me during the meeting for contemporaneous analysis of what has been said."
+
+Two capabilities, related but separable:
+
+1. **Streaming capture.** The recording exists server-side from the moment Record is pressed, and grows
+   as the meeting runs, instead of appearing in one multipart POST at Stop.
+2. **Live transcript.** That growing audio is transcribed as it arrives, so the transcript - and chat
+   over it - are usable while the meeting is still happening.
+
+(1) is worth shipping on its own and carries no AI risk. (2) is the point, and depends on (1).
+
+---
+
+## 2. Scope of the change against what exists today
+
+Today the whole capture path is a single deferred act. `apps/web/src/components/Recorder.tsx` accumulates
+every `MediaRecorder` chunk in `chunksRef` (line 326), assembles one `Blob` at `stop()` (line 1104), and
+POSTs it to `RecordingsController.Upload`. Nothing reaches the server until the meeting is over. The
+consequences are all downstream of that one fact:
+
+| Today | Cause |
+|---|---|
+| A three-hour meeting holds ~170 MB of Blobs in the tab | `chunksRef` grows for the whole recording |
+| A closed laptop lid loses the entire meeting | Audio only leaves the browser at Stop (`pendingRecording.ts` stashes to IndexedDB *after* stop, which does not help if the tab dies mid-meeting) |
+| Long meetings end with a single large upload | One multipart POST capped by `Uploads:MaxBytes` |
+| No transcript exists until after the meeting | No audio on the server until after the meeting |
+
+This spec changes only the transport and adds a provisional transcription pass. **The canonical
+transcript is produced exactly as it is today** - one full-file pass through the existing worker,
+`internal/transcriptions/result`, and every downstream job (summary, minutes, actions, tags,
+embeddings) unchanged.
+
+---
+
+## 3. The measurement that gates this
+
+Live chunked transcription is only possible if a chunk costs materially less wall-clock time than its
+own duration. If a 30 s chunk costs 45 s, the backlog grows without bound for the entire meeting and
+the transcript falls further behind the longer the meeting runs - a broken feature, not a slow one.
+
+This was measured on **2026-08-30** against the production CUDA box (RTX 5090) and a second box
+(RTX 4070 Laptop, 8 GB) for contrast. Method and reproduction are in §16.
+
+### 3.1 RTX 5090 - the production box
+
+End-to-end through the real Redis queue, timed by the worker's own `Transcription.ProcessingMs`
+(blob download + ASR + alignment + diarization + voiceprint embedding). Median of three passes.
+
+| Clip | Processing | xRealtime | Queue wait | Segments | Speakers found |
+|---:|---:|---:|---:|---:|---:|
+| 5 s | 0.72 s | 0.14x | 1.3 s | 1 | 1 |
+| 10 s | 1.01 s | 0.10x | 1.0 s | 1 | 1 |
+| 15 s | 1.40 s | 0.09x | 0.7 s | 3 | 1 |
+| **20 s** | **2.15 s** | **0.11x** | 1.7 s | 4 | 3 |
+| **30 s** | **2.67 s** | **0.09x** | 1.7 s | 6 | 2 |
+| **45 s** | **2.76 s** | **0.06x** | 1.2 s | 10 | 2 |
+| 60 s | 3.68 s | 0.06x | 0.6 s | 13 | 2 |
+| 90 s | 4.01 s | 0.04x | 0.3 s | 19 | 2 |
+| 120 s | 4.94 s | 0.04x | 1.2 s | 27 | 2 |
+| 180 s | 6.36 s | 0.04x | 1.3 s | 41 | 2 |
+| 240 s | 8.05 s | 0.03x | 1.0 s | 57 | 2 |
+
+Least-squares fit: **1.26 s fixed + 0.029 s per second of audio**, accurate to within 2% at the long
+end. The bold rows are the plausible live-chunk sizes. **A 30 s chunk costs 2.67 s measured - 91%
+headroom against its own duration.**
+
+### 3.2 Validated against real recordings
+
+Synthetic speech is cleaner than a meeting (no overlap, no room noise, few speakers), so the fit was
+checked against **58 real recordings already on the instance** - median 62 min, longest 227 min, up to
+49 speakers, 73.5 hours in total. Aggregate statistics only; no recording content, title, or
+participant was read.
+
+| Statistic | Realtime factor |
+|---|---:|
+| p10 | 0.0183 |
+| **median** | **0.0205 (~49x realtime)** |
+| p90 | 0.0329 |
+| worst observed | 0.0482 (~21x realtime) |
+
+Real audio is **cheaper** per second than the synthetic ladder, not dearer - the ladder is dominated by
+the fixed floor at short lengths. There is no hidden difficulty in real meetings that the synthetic
+test missed.
+
+### 3.3 RTX 4070 Laptop, 8 GB - the hardware floor
+
+Run directly inside the worker image with per-stage timing, which is what shows where the cost sits.
+
+| Clip | Total | xRealtime | ASR | Diarize | Align | Embeddings |
+|---:|---:|---:|---:|---:|---:|---:|
+| 5 s | 0.84 s | 0.17x | 0.72 s | 0.04 s | 0.03 s | 0.01 s |
+| 10 s | 1.03 s | 0.10x | 0.85 s | 0.05 s | 0.05 s | 0.02 s |
+| 15 s | 1.54 s | 0.10x | 1.18 s | 0.21 s | 0.08 s | 0.02 s |
+| 20 s | 13.50 s | 0.68x | 2.95 s | 10.36 s | 0.11 s | 0.03 s |
+| 30 s | 24.36 s | 0.81x | 5.04 s | 19.07 s | 0.17 s | 0.02 s |
+| 45 s | 37.98 s | 0.84x | 8.80 s | 28.80 s | 0.28 s | 0.03 s |
+| 60 s | 48.41 s | 0.81x | 9.47 s | 38.47 s | 0.35 s | 0.04 s |
+| 90 s | 83.99 s | 0.93x | 16.28 s | 67.07 s | 0.51 s | 0.06 s |
+| 120 s | 118.63 s | 0.99x | 22.03 s | 95.71 s | 0.72 s | 0.08 s |
+| 180 s | 191.33 s | **1.06x** | 32.79 s | 153.61 s | 3.64 s | 1.18 s |
+| 240 s | 253.48 s | **1.06x** | 44.26 s | 201.79 s | 4.99 s | 2.31 s |
+
+Three findings, all load-bearing for the design:
+
+- **Diarization is 75-80% of every chunk.** ASR is a quarter; alignment and voiceprint embedding are
+  rounding errors. The proportion holds on the 5090; only the absolute numbers change.
+- **Short clips are cheap for the wrong reason.** The 5-15 s clips contain one speaker, so pyannote's
+  clustering has nothing to do. The step at 20 s is where the second voice appears, **not** a duration
+  threshold. Any chunk-size decision must read the 20 s row, never the 15 s one.
+- **8 GB is not enough.** The card sat at 7804 of 8188 MiB (95% of VRAM) at 100% utilisation, crossed
+  1.0x realtime at about 150 s, and settled at 1.06x. Alignment and embedding - free on the 5090 and
+  free here up to 120 s - start costing whole seconds on the longest clips, which is the signature of
+  memory pressure rather than a slow card. Cold start into VRAM was 57.8 s.
+
+Both boxes produced **identical segment counts and speaker labels at every clip length**, which is what
+makes the comparison trustworthy: the fast box is doing the same work, not skipping diarization.
+
+A single straight-line fit is valid for the 5090 but **not** for the 4070, whose curve has a step change
+at 20 s; fitting one line across it yields a negative intercept, which is an artefact of the regime
+change rather than a floor.
+
+### 3.4 What the measurement decides
+
+| Question | Answer |
+|---|---|
+| Can a chunk be transcribed faster than realtime? | Yes, by 10-30x on the production box. |
+| Must the live pass use a smaller model? | No. `large-v3` is fine. |
+| Must the live pass use a hosted `/audio/transcriptions` endpoint? | No - which also means audio never leaves the deployment. |
+| Does live need a second worker process holding a second copy of the weights? | No (§6.3). |
+| Can the live pass afford diarization? | Yes. A diarized 30 s chunk costs 2.67 s. |
+| Can this run on any GPU? | **No.** 8 GB cannot. See §12.4. |
+
+---
+
+## 4. Correction to an existing figure
+
+The only worker throughput number recorded anywhere in the repo is
+`docs/Overall_Synopsis_of_Platform.md`'s **"~1.3-1.7x realtime for `large-v3`"**. That figure is correct
+but is measured on the **ROCm Strix Halo box** running the `openai-whisper` backend on an APU. It is
+**25-50x slower than the CUDA path** and must not be used to reason about the CUDA deployment.
+
+Consequence for this feature's rationale: on the CUDA box a 60-minute meeting occupies the worker for
+roughly **75 seconds**, so the transcript is readable about a minute and a half after Stop - not the
+~40 minutes the ROCm figure implies. **The value of this feature is therefore entirely in-meeting use.**
+It does not meaningfully shorten the wait afterwards, and should not be justified on that basis.
+
+`Overall_Synopsis_of_Platform.md` is updated in the same PR to attribute its figure to the ROCm box and
+record the CUDA one beside it.
+
+---
+
+## 5. Decisions taken
+
+### 5.1 D1 - chunk framing (**gated on a spike**)
+
+`MediaRecorder.start(timeslice)` emits chunks, but only the first carries the EBML header and Opus
+codec-private data; chunks two onward are not independently decodable by ffmpeg.
+
+| Option | Canonical audio | Live decode | Verdict |
+|---|---|---|---|
+| **A. Fragment + header prepend** - `start(timeslice)`, store every fragment, concatenate all fragments byte-wise for the canonical file, and prepend fragment 0 when decoding a live window | Byte-identical to today | Needs fragment 0 prepended | **Preferred**, subject to spike |
+| **B. Stop/restart per chunk** - each blob self-contained, as `dictationEngine.ts` `createServerEngine` already does | Loses a few ms per restart (~0.6 s scattered over a 60-min meeting at 30 s chunks) | Works unmodified | **Documented fallback** |
+| C. Raw PCM from an AudioWorklet | Lossless, but ~84 MB/hour against ~11 MB for Opus | Trivial | Rejected: 8x the bytes for a problem A or B already solves |
+
+**Spike S0 must run before anything else in Phase 1** and answers one question: does byte-concatenating
+`start(timeslice)` fragments reproduce a file ffmpeg decodes identically to the single-blob recording,
+and does `fragment[0] + fragment[k..n]` decode correctly, on Chrome, Firefox, Safari and Electron? If
+any browser says no, the spec falls back to option B and §7.2 gains a note that the canonical audio has
+sub-second scattered gaps.
+
+Option B is known to work - it is in production for dictation - so the spike is about whether A's
+better canonical audio is available, not about whether the feature is possible.
+
+### 5.2 D2 - overlap is a property of the decode window, not of the stored chunks
+
+Whisper on a clip that starts or ends mid-sentence produces noise at the seams. The fix is overlapping
+transcription windows, but overlapping *stored* chunks would duplicate audio and break the concat that
+produces the canonical file.
+
+**Resolution:** chunks are stored contiguous and non-overlapping. The live job carries the *previous*
+chunk's key, and the worker prepends `Live:OverlapMs` of its tail before transcribing. Results outside
+the chunk's own time range are discarded before they are persisted. Overlap costs nothing on disk and
+nothing in the concat path, and the 91% headroom pays for the extra audio comfortably.
+
+### 5.3 D3 - the live transcript is provisional and disposable
+
+The live pass writes a `Transcription` with `IsProvisional = true`. The final pass, after Stop, writes
+the next version in the normal way. `RecordingsController.Get` already returns only the highest version,
+so the provisional transcript is superseded automatically the moment the real one lands, and is retained
+for comparison exactly as any older version is.
+
+This is what keeps the change additive:
+
+- Nothing downstream reconciles partial results.
+- Seam errors and imperfect speaker labels never reach the record.
+- Summary, minutes, actions, tags and embeddings never run on provisional text (§7.2).
+- The final pass costs ~75 s on an hour of audio, so running it in full is not a sacrifice worth
+  optimising away.
+
+### 5.4 D4 - one recorder, not two
+
+An earlier draft proposed a second `MediaRecorder` on the same `MediaStream` so the canonical file
+stayed byte-identical while a separate chunked recorder fed the live path. **Rejected**, because with
+D1 option A the canonical file is already byte-identical, and a second recorder would double upload
+bytes and storage while deleting Phase 1's durability benefit (the canonical audio would still only
+arrive at Stop). If spike S0 forces option B *and* the scattered gaps prove audible, revisit this.
+
+### 5.5 D5 - no live RAG
+
+`EmbeddingProcessor` replaces a recording's `TranscriptChunk` rows wholesale, so re-running it every
+30 s would re-embed the whole meeting repeatedly. Chat over a live meeting pre-loads the transcript
+instead: an hour of talk is roughly eight to ten thousand tokens, well inside the context budget
+`ChatContextMeter` already manages. Retrieval is for the library; the meeting you are sitting in fits
+in the window.
+
+---
+
+## 6. Design
+
+### 6.1 Lifecycle
+
+```
+Record pressed
+  POST /api/recordings/live            -> Recording{Status=Live}, provisional Transcription v1
+  (repeat, every ~20-45 s)
+  PUT  /api/recordings/{id}/chunks/{n} -> blob to MinIO, RecordingChunk row, enqueue live-chunk job
+                                          worker -> internal/transcriptions/live-chunk
+                                          -> Segments appended to v1, SignalR LiveTranscriptAppended
+Stop pressed
+  POST /api/recordings/{id}/live/finalize
+                                       -> Status=Merging, enqueue audio-merge job over the chunks
+                                          worker concat -> canonical blob swapped onto the Recording
+                                          -> enqueue normal transcription job (v2, final)
+                                          -> existing callback path, unchanged from here on
+```
+
+### 6.2 New Redis stream
+
+A twelfth queue, `live-chunk-jobs`, consumed by the **Python worker** (its fourth stream, same
+`workers` consumer group, alongside `transcription-jobs`, `audio-merge-jobs` and `voiceprint-jobs`).
+
+Job payload, PascalCase per the existing cross-boundary contract:
+
+```
+LiveChunkJob {
+  RecordingId, TranscriptionId, Sequence, BlobKey,
+  PrevBlobKey,        // null for sequence 0
+  OffsetMs,           // chunk start, relative to the recording
+  OverlapMs,          // how much of PrevBlobKey to prepend
+  Language            // resolved the same way EnqueueTranscriptionAsync resolves it
+}
+```
+
+Callback `POST internal/transcriptions/live-chunk`, `X-Worker-Secret` as usual:
+
+```
+LiveChunkResult {
+  RecordingId, TranscriptionId, Sequence, Language,
+  Segments: [{ Speaker, StartMs, EndMs, Text, Words }],   // already offset into recording time
+  Speakers: [{ Speaker, Embedding }],                     // 192-d ECAPA, as the existing callback
+  ProcessingMs
+}
+```
+
+### 6.3 Worker loop: priority read
+
+`run_loop` currently issues one blocking `XREADGROUP` across its streams with `count=1` and handles jobs
+serially. Adding a fourth stream naively would let a live chunk queue behind a full-meeting job.
+
+**Change:** a non-blocking `XREADGROUP` on `live-chunk-jobs` first; fall through to the existing blocking
+multi-stream read only when it is empty. That bounds live latency by the *in-flight* job's remaining
+time rather than by queue depth.
+
+A live chunk can still wait behind one in-flight full-meeting transcription. Measured, that is ~75 s for
+a 60-minute recording - a visible stall, but bounded and rare. A second worker process is **not**
+specified; if production telemetry shows it biting, it is a configuration change (a second container
+consuming only `live-chunk-jobs`), not a redesign. Note that a second process costs a second copy of the
+model weights, which §3.3 shows is not free on a small card.
+
+### 6.4 Cross-chunk speaker identity
+
+pyannote clusters over whatever audio it is given, so `SPEAKER_00` in chunk 3 has no relationship to
+`SPEAKER_00` in chunk 4. Per-chunk labels shown raw would reshuffle every 30 s - worse than no
+attribution, because it reads as though it means something.
+
+The stitcher is a new **pure** service, `LiveSpeakerStitcher`:
+
+- Keeps a running set of session centroids, one per live label, as a mean of the ECAPA vectors seen for
+  that label (stored on `Speaker.Embedding`, which already exists and is `vector(192)`).
+- For each chunk-local label, ranks its embedding against the session centroids by cosine distance.
+  Accept the best match when it clears `Live:StitchThreshold` **and** beats the runner-up by
+  `Live:StitchMargin`; otherwise mint a new live label.
+- Independently ranks against the platform voiceprint directory via the existing `ISpeakerIdentifier`,
+  reusing `IdentificationRules.Decide`, so a known colleague gets a real name rather than
+  `SPEAKER_01`.
+
+Two measured caveats the design must tolerate:
+
+- ECAPA on 15-30 s of one voice is noisy. This is the real floor under chunk length, not compute.
+- pyannote found **three** speakers in a 20 s clip containing two. Short-window clustering
+  over-segments, so the stitcher must merge chunk-local labels onto one session label, never assume a
+  bijection.
+
+**A live match must never enrol.** The existing rule that automatic identification does not write a
+`VoiceSample` holds here without exception: provisional, short-window matches are exactly the input that
+should not be allowed to pollute a platform-wide centroid (see the identification notes in `CLAUDE.md`).
+
+### 6.5 SignalR
+
+One new event on the existing `TranscriptionHub`, scoped to the per-user group as everything else is:
+
+```
+LiveTranscriptAppended { recordingId, transcriptionId, sequence, segments[], speakers{} }
+```
+
+`RecordingStatusChanged` continues to carry lifecycle transitions, including the new `Live` status, so
+list views need no new subscription.
+
+### 6.6 Chat
+
+No change to `ChatController`. It loads the current transcription's segments ordered by `Ordinal` with
+no status filter, so a provisional transcription is picked up as-is. Two adjustments elsewhere:
+
+- `ChatContextBuilder` marks provisional content in the prompt, so the model knows the meeting is still
+  running and does not describe a partial discussion as concluded.
+- Live RAG is off (D5).
+
+---
+
+## 7. Schema changes
+
+All additive. See `docs/Data_Schema.md`, updated in the implementing PR.
+
+### 7.1 New entity `RecordingChunk`
+
+| Column | Type | Notes |
+|---|---|---|
+| `Id` | uuid PK | |
+| `RecordingId` | uuid FK -> `Recordings` | cascade delete |
+| `Sequence` | int | 0-based; unique with `RecordingId` |
+| `BlobKey` | text | `{userId}/{recordingId}/chunks/{sequence:D5}.webm` |
+| `StartMs` / `EndMs` | bigint | relative to the recording |
+| `SizeBytes` | bigint | counts toward quota until finalise (§12.1) |
+| `ReceivedAt` | timestamptz | |
+| `TranscribedAt` | timestamptz null | null = enqueued but not yet returned |
+
+Unique index on `(RecordingId, Sequence)` - the idempotency key for retries (§9.2). Rows and blobs are
+deleted after a successful concat.
+
+### 7.2 `Transcription.IsProvisional`
+
+`bool`, default `false`. Set on the live pass only. Every consumer that must not act on provisional text
+gates on it:
+
+| Consumer | Behaviour when `IsProvisional` |
+|---|---|
+| `SummarizationWorker`, `ActionsWorker`, `TagsWorker`, `MeetingMinutesWorker` | never enqueued |
+| `EmbeddingWorker` | never enqueued (D5) |
+| `WebhookEventTypes.RecordingTranscribed` | not published |
+| Transcript export endpoints (`transcript.txt/md/rtf/srt`) | 409 with an explanatory message |
+| MCP tools, `SearchController` | excluded from results |
+| `RecordingsController.Get` | returned as normal, with the flag on `TranscriptionDto` so the UI can label it |
+
+### 7.3 `RecordingStatus.Live = 8`
+
+Append-only, following `Merging = 7`. Never renumber - values persist as ints.
+
+### 7.4 Backup-restore
+
+None of this is destructive and an older backup restores unchanged, so
+`MaintenanceController.CurrentFormat` is **not** bumped. A restored backup can contain a `Live`
+recording that no client will ever finalise; the reaper in §9.4 collects it on the same timer as any
+other abandoned session.
+
+---
+
+## 8. API surface
+
+| Endpoint | Purpose |
+|---|---|
+| `POST /api/recordings/live` | Begin. Body mirrors the `Upload` form fields (title, source, startedAt, roomId, sectionId) minus the audio. Enforces the same room permission check. Returns the recording id. |
+| `PUT /api/recordings/{id}/chunks/{sequence}` | One chunk, multipart. Idempotent on `(id, sequence)`. Rejects when the recording is not `Live` or not the caller's. |
+| `POST /api/recordings/{id}/live/finalize` | Stop. Concats, then runs the normal transcription. Reports which sequences are missing if there is a gap (§9.2). |
+| `DELETE /api/recordings/{id}/live` | Abandon and discard. |
+
+Quota is charged at `POST /api/recordings/live` against a caller-declared expected duration, and
+reconciled at finalise - a live recording cannot know its size in advance, and the existing check in
+`Upload` runs against a known `audio.Length` (§12.1).
+
+---
+
+## 9. Edge cases and failure modes
+
+### 9.1 The network drops mid-meeting
+
+Chunks queue client-side in IndexedDB (the `pendingRecording.ts` pattern, extended to a queue keyed by
+sequence) and upload when connectivity returns. Recording never blocks on the network.
+
+### 9.2 A chunk is lost
+
+`PUT .../chunks/{sequence}` is idempotent on `(RecordingId, Sequence)`, so a retry is safe. `finalize`
+computes the expected sequence set from the highest sequence received and refuses to concat if any are
+missing, returning the gap. The client retries the named sequences from its IndexedDB queue, then
+finalises again. Only if a chunk is genuinely unrecoverable does the user get a choice: finalise with a
+gap, or keep waiting.
+
+### 9.3 The recording is paused
+
+The recorded clock is already pause-aware (`Recorder.tsx` `timing.pause`). Chunk boundaries are driven
+by that clock, so a pause simply stops producing chunks. `StartMs`/`EndMs` stay in recorded time, which
+is what `Segment` offsets already mean.
+
+### 9.4 The client vanishes (lid closed, tab killed, browser crash)
+
+A new hosted service reaps `Live` recordings whose newest chunk is older than `Live:AbandonAfterMinutes`
+(default 30): finalise from whatever arrived, or delete if no chunk ever did. **This is a strict
+improvement over today**, where the same event loses the entire meeting.
+
+### 9.5 Two devices, one account
+
+`POST /api/recordings/live` takes a client-generated session id and the chunk endpoint requires it. A
+second device gets 409 rather than interleaving its chunks into the first device's recording. The
+desktop single-instance lock covers one shell, not one account, so this cannot be left to the client.
+
+### 9.6 The GPU cannot keep up
+
+If `TranscribedAt` lag exceeds `Live:MaxLagSeconds`, the API stops enqueueing live jobs for that
+recording, emits a `LiveTranscriptDegraded` event, and the UI says the live transcript has paused and
+will be complete after the meeting. **Capture is unaffected** - chunks keep uploading, and the final
+transcript is unharmed. This is the designed response to §12.4 hardware, and to unexpected load.
+
+### 9.7 Silence
+
+A chunk with no speech returns no segments. That is normal mid-meeting and must not be treated as the
+failure `WorkerCallbackController.Result` reports for a whole recording with no speech.
+
+---
+
+## 10. UX
+
+The live transcript renders in the existing in-meeting surface rather than a new one: the notes panel
+(`useLiveNotes` / `useNotesPopout` / `notesChannel.ts`) gains a **Transcript** tab beside Notes, and it
+travels into the pop-out window with the notes. Chat is reachable from the same place and is scoped to
+the running recording.
+
+- Provisional text is visually distinguished (the tail of the transcript is not yet stable, and speaker
+  labels can be revised by the stitcher).
+- A speaker rename during the meeting applies to the session label and is preserved onto the final
+  transcript by the existing rename-preservation rule.
+- A status line shows how far behind the transcript is, so the §9.6 degradation is legible rather than
+  mysterious.
+
+Help content (`apps/web/src/content/help/**`) gains an article, since this changes behaviour a user
+relies on.
+
+---
+
+## 11. Testing (TDD, per CLAUDE.md)
+
+Failing test first, in every case. New pure modules exist precisely so they can be tested without a
+media stream, a GPU, or a browser.
+
+| File | Kind | Covers |
+|---|---|---|
+| `apps/web/src/lib/liveChunker.test.ts` | vitest, pure | Boundary decisions from (level, elapsed, pause state): cut at the first >= `PauseMs` silence after `MinMs`; force at `MaxMs`; never cut while paused |
+| `apps/web/src/lib/liveChunkQueue.test.ts` | vitest, pure | Sequence assignment, retry ordering, gap detection, IndexedDB degradation to memory-only |
+| `apps/web/src/lib/liveTranscript.test.ts` | vitest, pure | Applying an append event: ordering by sequence, idempotent re-delivery, speaker relabelling |
+| `tests/Diariz.Api.Tests/LiveSpeakerStitcherTests.cs` | xUnit, pure | Cosine matching with hand-built vectors: merge onto an existing label, mint a new one, over-segmentation (3 chunk labels onto 2 session labels), never enrol |
+| `tests/Diariz.Api.Tests/LiveRecordingControllerTests.cs` | xUnit, in-memory | Ownership, room permission, idempotent chunk PUT, 409 on a foreign session id, finalize gap reporting |
+| `tests/Diariz.Api.Tests/ProvisionalTranscriptionGateTests.cs` | xUnit, in-memory | Every consumer in §7.2 declines provisional input |
+| `tests/Diariz.Api.IntegrationTests/LiveChunkFlowTests.cs` | Testcontainers | Real MinIO round-trip, the `(RecordingId, Sequence)` unique constraint, `live-chunk-jobs` wire format, cascade delete |
+| `src/Diariz.Worker/tests/test_live_chunk.py` | pytest, models stubbed | Job orchestration, overlap prepend and trim-back, temp cleanup, callback body shape |
+
+The web suite's `act()` guard and pristine-output rule apply as everywhere else. Note that a local
+Windows run cannot be trusted to reproduce CI (`vitest.config.ts` reporter caveat in `CLAUDE.md`); run
+the suite on Linux before claiming it passes.
+
+---
+
+## 12. Second-order consequences
+
+### 12.1 Storage quota
+
+Chunks plus a concatenated blob charge the owner twice until cleanup. Today `SizeBytes` is set once from
+a known `audio.Length` before anything is stored. Live recordings must instead charge incrementally as
+chunks arrive and reconcile at finalise, and the reaper (§9.4) must release the charge for an abandoned
+session.
+
+### 12.2 Retention
+
+`AudioRetention` operates on `Recording.CreatedAt`. A `Live` recording is not a candidate until
+finalised; the reaper handles the rest.
+
+### 12.3 Queue contention
+
+Downgraded from a headline risk by §3. A 60-minute meeting occupies the serial worker ~75 s, so a live
+chunk waits a minute or two at worst. The priority read (§6.3) is specified; a second worker process is
+not.
+
+### 12.4 Hardware floor
+
+**New constraint.** §3.3 shows an 8 GB GPU cannot run this pipeline live. Live transcription must
+therefore be a capability the server determines at startup - from available VRAM and a timed probe -
+and advertises through `ConfigController`, rather than a flag an operator sets by hand and discovers is
+wrong mid-meeting. When it is off, the recorder falls back to today's behaviour exactly.
+
+### 12.5 Privacy
+
+Audio leaves the device continuously rather than in one deliberate act at Stop. Because §3 removed any
+need for a hosted transcription endpoint, it still never leaves the deployment - so this is a change in
+timing, not in trust boundary. Worth stating plainly in the help article all the same.
+
+---
+
+## 13. Non-goals
+
+- **Sub-five-second latency.** That rules out chunked file transcription entirely and points at a
+  streaming ASR service - a different project. Lag here is dominated by the chunk length, floored by
+  speaker-clustering quality (§6.4), not by the GPU.
+- **Live summary, minutes, actions or tags.** Provisional text, repeated LLM spend, and a moving target.
+  All of it runs once, at the end, unchanged.
+- **Live translation.**
+- **Mobile.** M4's mobile app is not built; nothing here assumes it.
+- **Carrying live segments forward into the final transcript.** The final pass supersedes them (D3).
+  Reconciliation is a later option, not part of this.
+- **Multi-device capture into one recording.** Explicitly refused (§9.5).
+
+---
+
+## 14. Acceptance criteria
+
+1. Pressing Record creates a `Recording` server-side with `Status = Live`, visible in the list, before
+   any audio is captured.
+2. Audio arrives continuously; killing the tab mid-meeting loses at most the last chunk, and the
+   recording is recoverable by the reaper.
+3. A transcript appears in the notes panel within `chunk length + ~5 s` of speech and continues to
+   update, with a visible lag indicator.
+4. Chat answers questions about what has been said so far, while the meeting runs.
+5. Speaker labels remain stable for the duration of the meeting; an enrolled colleague is named.
+6. On Stop, the canonical blob is byte-identical to what today's path would have produced (D1 option A),
+   and the final transcript is produced by the existing unchanged pipeline.
+7. No summary, minutes, actions, tags, embeddings, webhook or export is ever produced from provisional
+   text.
+8. With live transcription unavailable (§12.4) or degraded (§9.6), recording and the final transcript
+   are indistinguishable from today.
+9. `dotnet test`, `npm test` (on Linux) and `python -m pytest` all pass with no new warnings.
+
+---
+
+## 15. Implementation plan
+
+Five PRs. Each is independently shippable and independently revertible.
+
+| # | PR | Risk | Ships |
+|---|---|---|---|
+| S0 | **Framing spike** (§5.1) | - | A findings section appended to this doc. No product code. |
+| 1 | **Streaming capture** - chunk upload, concat at finalise, reaper, quota reconciliation. No live transcript. | Low | Durability during the meeting, no upload cliff, no client memory growth |
+| 2 | **Live transcript, session-local labels** - `live-chunk-jobs`, worker handler, provisional transcription, SignalR, notes-panel tab | Medium | The transcript during the meeting |
+| 3 | **Cross-chunk speaker identity** - `LiveSpeakerStitcher`, directory matching | Medium | Stable speakers, real names |
+| 4 | **Chat over the live transcript** - provisional marking in the context builder, in-meeting entry point | Low | The stated goal |
+
+PR 1 is worth shipping even if 2-4 never happen. PR 4 is small because §6.6 requires almost nothing.
+
+### Release checklist impact
+
+**This doc is a docs-only change**: no version bump, no `RELEASES` entry, no `CAPABILITIES` or README
+edit. It does update `Overall_Synopsis_of_Platform.md` for the throughput correction in §4, which is a
+factual fix to an existing document rather than a new claim about the product.
+
+Each implementation PR does the full checklist in `CLAUDE.md`: version + seven mirrors, a `RELEASES`
+entry, and - because this adds a user-facing capability - the README Features row, the `docs/features.md`
+bullet and the About-box `CAPABILITIES` row in lockstep. PR 1 and PR 2 both touch
+`Overall_Synopsis_of_Platform.md` (new stream, new contract, new hosted service) and `Data_Schema.md`
+(new entity, new column, new enum value).
+
+---
+
+## 16. Appendix - measurement method
+
+Reproducible without any production data.
+
+**Test audio.** A synthetic two-speaker "meeting" generated with Windows TTS (two English voices,
+varied speaking rate, invented content), rendered to 16 kHz mono 16-bit WAV, then sliced with Python's
+stdlib `wave` module into a contiguous ladder of 5, 10, 15, 20, 30, 45, 60, 90, 120, 180 and 240 s
+clips from a common 2 s offset. Only the length varies across the ladder.
+
+**Two harnesses:**
+
+- *In-container, per-stage.* Replicates `pipeline.transcribe()` stage by stage with a timer around each
+  call, run inside the worker image with the models warm. Must apply `rocm_env.clean_gfx_override()` and
+  `torch_compat.restore_legacy_torch_load()` before importing `pipeline` - `worker.py` does this and a
+  script that imports `pipeline` directly does not, so the pyannote VAD checkpoint fails to load on
+  torch >= 2.6 without it.
+- *Via the REST API, end-to-end.* Uploads each clip, polls until transcribed, and reads
+  `RecordingDetailDto.Current.ProcessingMs` (note: the field is `current`, not `transcription`). Needs
+  only a `dz_api_` token, so it works against any instance without shell access. It reports queue wait
+  separately from processing time so contention is visible rather than silently inflating results.
+
+**Hygiene.** Benchmark recordings are titled `floor-bench <n>s`. Cleanup matches on `Recording.Title`,
+never `Name` - the summariser overwrites `Name` and would defeat a name-based filter, while `Title` is
+the auto descriptor and stays stable. All 33 benchmark recordings created for §3.1 were deleted
+afterwards and the instance was verified back to its prior count.
+
+**Caveats on these numbers.**
+
+- The 5090 box was effectively idle (queue waits 0.3-1.7 s). Behaviour under concurrent load is
+  unmeasured, which is why §9.6 exists.
+- Synthetic speech has clean turn-taking and no overlap. §3.2 exists because of that, and shows real
+  audio is cheaper, not dearer.
+- Each API-route upload also triggers the owner's summary/actions/tags jobs, so a re-run spends LLM
+  calls. Use the in-container harness where that matters.

--- a/tools/transcription-bench/.gitignore
+++ b/tools/transcription-bench/.gitignore
@@ -1,0 +1,8 @@
+# Generated benchmark material and output. The audio is synthesised on demand by
+# make-audio.ps1 and sliced by slice.py, so there is nothing to preserve here - and
+# checking in WAVs would put tens of MB of binary into a repo that has no need of it.
+base.wav
+clips/
+clips-*/
+*.json
+*.log

--- a/tools/transcription-bench/README.md
+++ b/tools/transcription-bench/README.md
@@ -1,0 +1,112 @@
+# transcription-bench
+
+Measures how long the transcription pipeline takes on short clips, so a chunk size for live
+transcription can be chosen from data rather than guessed.
+
+The question these answer: **as a clip gets shorter, what does the per-job cost converge to?**
+That fixed floor decides whether live chunked transcription can keep up with a meeting - a 30 s
+chunk costing 45 s of wall clock falls behind without bound for the whole meeting.
+
+Results, interpretation and the design they informed:
+[`docs/Streaming_Capture_and_Live_Transcript.md`](../../docs/Streaming_Capture_and_Live_Transcript.md)
+sections 3 and 16.
+
+Nothing here is part of a deployable. It is developer tooling, run by hand.
+
+## The two harnesses
+
+|  | `chunk_floor.py` | `api_floor.py` |
+|---|---|---|
+| Runs | inside the worker container | anywhere, against a REST endpoint |
+| Needs | Docker + the GPU + the image | a `dz_api_` token |
+| Reports | **per stage** - decode, ASR, align, diarize, shape, embeddings | total `ProcessingMs` + queue wait |
+| Touches the instance | no - reads the models and nothing else | yes - creates and deletes recordings |
+
+Prefer `chunk_floor.py`. The per-stage breakdown is what tells you *why* a chunk costs what it
+does (diarization is 75-80% of it), and it has no side effects. Use `api_floor.py` when you have
+no shell on the box, or to confirm the queue behaves end to end.
+
+## Generating the test audio
+
+Synthetic, so benchmark material is never production audio.
+
+```powershell
+.\make-audio.ps1        # Windows TTS -> base.wav (two voices, ~290 s, invented content)
+python slice.py         # -> clips/clip-005s.wav ... clip-240s.wav
+```
+
+`make-audio.ps1` needs two English Windows TTS voices (Hazel and Zira by default). On a machine
+without them, edit the `$turns` voice names, or supply any other two-speaker WAV as
+`slice.py --src`.
+
+**One property of this ladder matters when reading results.** The opening turns are long, so
+clips shorter than about 20 s contain a *single* speaker and pyannote's clustering has almost
+nothing to do. They are therefore far cheaper than a real chunk would be. The step at 20 s is
+the second voice arriving, not a duration threshold. Size a chunk against the 20 s row, never
+the 15 s one.
+
+## Running it
+
+Inside the worker image, per stage:
+
+```powershell
+.\run-local.ps1 -Build                       # first time: builds diariz-worker:bench
+.\run-local.ps1 -Repeats 3 -JsonOut local.json
+```
+
+Against a remote instance, end to end:
+
+```bash
+export DIARIZ_TOKEN=dz_api_...               # or pass --token
+python api_floor.py --base http://host:8080 --clips ./clips --repeats 3
+```
+
+Check that the fast box really diarized rather than silently skipping the expensive stage:
+
+```bash
+python speakers.py --base http://host:8080   # while the recordings still exist
+```
+
+Check the synthetic fit against real audio, which has overlap, noise and more speakers:
+
+```bash
+python validate.py --base http://host:8080 --floor 1.26 --slope 0.029
+```
+
+Remove anything an interrupted run left behind:
+
+```bash
+python cleanup.py --base http://host:8080            # dry run
+python cleanup.py --base http://host:8080 --delete
+```
+
+## Things that will catch you out
+
+**`chunk_floor.py` must apply the worker's shims before importing `pipeline`.** It calls
+`rocm_env.clean_gfx_override()` and `torch_compat.restore_legacy_torch_load()` first, because
+`worker.py` does and a script that imports `pipeline` directly does not. Without them the
+pyannote VAD checkpoint fails to load on torch >= 2.6 with *"Weights only load failed ...
+Unsupported global"*, and an empty `HSA_OVERRIDE_GFX_VERSION` silently drops a ROCm box to CPU.
+
+**`api_floor.py` costs LLM calls.** Each upload also triggers the owner's summary, actions and
+tags jobs. A full ladder at three repeats is 33 uploads. Use `--only 20,30,45` to shorten it, or
+prefer `chunk_floor.py`.
+
+**Cleanup matches on `Recording.Title`, never `Name`.** The summariser overwrites `Name` with a
+generated title - it will invent a plausible meeting name even for synthetic audio - so a
+name-based filter stops matching the moment summarisation runs. `Title` is the auto descriptor
+and stays `floor-bench <n>s`.
+
+**A negative "fixed floor" means the fit is invalid.** Both harnesses fit `total = floor +
+slope * seconds`. That holds only when the curve has no regime change. A GPU that runs out of
+memory partway up the ladder produces a step, and one line across a step yields a negative
+intercept. Read such a ladder row by row. Prefer a measured row over the fit generally - the fit
+is least accurate mid-ladder, which is exactly where the live chunk sizes are.
+
+**`validate.py` is the only tool here that reads production data.** It reports counts, ratios
+and percentiles only. Keep it that way: this repo is public, and the people in those recordings
+did not consent to appearing in it.
+
+## Generated files
+
+`base.wav`, `clips/`, `clips-*/`, and any `*.json` / `*.log` output are git-ignored.

--- a/tools/transcription-bench/_client.py
+++ b/tools/transcription-bench/_client.py
@@ -1,0 +1,65 @@
+"""Shared REST helpers for the transcription-bench tools. Stdlib only.
+
+The token may be passed with --token or, preferably, in the DIARIZ_TOKEN environment
+variable so it does not land in shell history. A personal API token (dz_api_...) with
+ReadWrite scope is what the write paths need; the read-only tools work with either scope.
+"""
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+
+
+def add_common_args(parser) -> None:
+    """Register --base and --token on an argparse parser."""
+    parser.add_argument("--base", required=True, help="instance root, e.g. http://192.168.1.129:8080")
+    parser.add_argument("--token", default=None,
+                        help="personal API token (dz_api_...); defaults to $DIARIZ_TOKEN")
+
+
+def resolve(args) -> tuple[str, str]:
+    """Return (base, token), preferring the environment for the token."""
+    token = args.token or os.environ.get("DIARIZ_TOKEN")
+    if not token:
+        sys.exit("no token: pass --token or set DIARIZ_TOKEN")
+    return args.base.rstrip("/"), token
+
+
+def request(method: str, url: str, token: str, body=None, content_type=None, timeout=120):
+    """One REST call. Returns (status, parsed-json-or-bytes); HTTP errors are returned,
+    not raised, so a caller can report them per item instead of aborting a whole run."""
+    req = urllib.request.Request(url, data=body, method=method)
+    req.add_header("Authorization", f"Bearer {token}")
+    if content_type:
+        req.add_header("Content-Type", content_type)
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:
+            raw = resp.read()
+            return resp.status, (json.loads(raw) if raw and raw[:1] in (b"{", b"[") else raw)
+    except urllib.error.HTTPError as e:
+        return e.code, e.read().decode("utf-8", "replace")
+
+
+def get_json(base: str, path: str, token: str, timeout: int = 60):
+    """GET that raises on anything but 200 - for calls where failure is fatal."""
+    status, data = request("GET", f"{base}{path}", token, timeout=timeout)
+    if status != 200:
+        sys.exit(f"GET {path} failed: HTTP {status}")
+    return data
+
+
+def list_recordings(base: str, token: str) -> list:
+    """The caller's recordings, as a list regardless of envelope shape."""
+    data = get_json(base, "/api/recordings", token)
+    return data if isinstance(data, list) else data.get("items", [])
+
+
+# Benchmark recordings are titled with this prefix. Cleanup matches on Recording.Title and
+# never on Name: the summariser overwrites Name with a generated title, so a name-based
+# filter would stop matching the moment summarisation ran.
+MARKER = "floor-bench"
+
+
+def bench_recordings(base: str, token: str) -> list:
+    return [r for r in list_recordings(base, token) if str(r.get("title", "")).startswith(MARKER)]

--- a/tools/transcription-bench/api_floor.py
+++ b/tools/transcription-bench/api_floor.py
@@ -1,0 +1,196 @@
+"""Measure the per-chunk floor through the REST API, with no shell access to the box.
+
+Uploads each clip as a recording, waits for it to transcribe, and reads back
+Transcription.ProcessingMs - the worker's own full-pipeline wall clock (blob download + ASR +
+alignment + diarization + voiceprint embedding). That is exactly the number that decides
+whether live chunked transcription keeps up.
+
+Less informative than chunk_floor.py (no per-stage breakdown) but needs only a token.
+
+    DIARIZ_TOKEN=dz_api_... python api_floor.py --base http://host:8080 --clips ./clips
+
+SIDE EFFECTS on the target instance - read before running:
+  - Creates one recording per clip per repeat. Deleted afterwards unless --keep is passed.
+  - Each transcription may trigger the owner's summary / actions / tags / embedding jobs,
+    which spend real LLM calls. Use --only to shorten the ladder if that matters, or prefer
+    chunk_floor.py, which touches nothing.
+  - Runs on the shared GPU queue, so a clip can sit behind a real job. Queue wait is reported
+    separately from ProcessingMs so contention stays visible instead of inflating results.
+"""
+import argparse
+import glob
+import json
+import mimetypes
+import os
+import statistics
+import sys
+import time
+import uuid
+
+import _client
+
+POLL_S = 2.0
+# Transcribed is enough - the later summarisation states do not change ProcessingMs.
+DONE = {"Transcribed", "Summarized", "Summarizing"}
+FAILED = {"Failed"}
+
+
+def multipart(fields: dict, file_field: str, path: str) -> tuple[bytes, str]:
+    """Build a multipart/form-data body. Stdlib only - no requests dependency."""
+    boundary = f"----diariz{uuid.uuid4().hex}"
+    out = bytearray()
+    for k, v in fields.items():
+        out += f"--{boundary}\r\n".encode()
+        out += f'Content-Disposition: form-data; name="{k}"\r\n\r\n'.encode()
+        out += f"{v}\r\n".encode()
+    name = os.path.basename(path)
+    ctype = mimetypes.guess_type(name)[0] or "application/octet-stream"
+    with open(path, "rb") as f:
+        data = f.read()
+    out += f"--{boundary}\r\n".encode()
+    out += f'Content-Disposition: form-data; name="{file_field}"; filename="{name}"\r\n'.encode()
+    out += f"Content-Type: {ctype}\r\n\r\n".encode()
+    out += data + b"\r\n"
+    out += f"--{boundary}--\r\n".encode()
+    return bytes(out), f"multipart/form-data; boundary={boundary}"
+
+
+def measure(base: str, token: str, path: str, secs: float, timeout_s: float) -> dict:
+    body, ctype = multipart(
+        {"title": f"{_client.MARKER} {secs:.0f}s", "durationMs": int(secs * 1000), "source": "Upload"},
+        "audio", path)
+
+    t_upload = time.perf_counter()
+    status, resp = _client.request("POST", f"{base}/api/recordings", token, body, ctype, timeout=300)
+    upload_s = time.perf_counter() - t_upload
+    if status not in (200, 201):
+        return {"error": f"upload HTTP {status}: {str(resp)[:200]}"}
+
+    rec_id = resp["id"]
+    t0 = time.perf_counter()
+    last = None
+    while time.perf_counter() - t0 < timeout_s:
+        time.sleep(POLL_S)
+        status, detail = _client.request("GET", f"{base}/api/recordings/{rec_id}", token)
+        if status != 200:
+            return {"id": rec_id, "error": f"poll HTTP {status}"}
+        last = detail.get("status")
+        if last in FAILED:
+            return {"id": rec_id, "error": f"transcription failed: {detail.get('error')}"}
+        # RecordingDetailDto names the current transcription "Current", not "transcription".
+        if last in DONE and detail.get("current"):
+            wall_s = time.perf_counter() - t0
+            tr = detail["current"]
+            proc_ms = tr.get("processingMs")
+            return {
+                "id": rec_id,
+                "upload_s": upload_s,
+                "wall_s": wall_s,
+                "processing_s": (proc_ms / 1000.0) if proc_ms else None,
+                "queue_s": (wall_s - proc_ms / 1000.0) if proc_ms else None,
+                "segments": len(tr.get("segments") or []),
+                "speakers": len(detail.get("speakerNames") or {}),
+            }
+    return {"id": rec_id, "error": f"timed out after {timeout_s:.0f}s (last status {last})"}
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    _client.add_common_args(ap)
+    ap.add_argument("--clips", required=True, help="directory of clip-NNNs.wav files")
+    ap.add_argument("--repeats", type=int, default=3)
+    ap.add_argument("--only", default=None,
+                    help="comma-separated clip lengths to run, e.g. 20,30,45 (default: all)")
+    ap.add_argument("--keep", action="store_true", help="do not delete the test recordings afterwards")
+    ap.add_argument("--timeout", type=float, default=300)
+    ap.add_argument("--json", dest="json_out", default=None)
+    args = ap.parse_args()
+
+    base, token = _client.resolve(args)
+    health = _client.get_json(base, "/health", token, timeout=15)
+    print(f"target        {base}   version {health.get('version')}")
+
+    ladder = []
+    for p in sorted(glob.glob(os.path.join(args.clips, "*.wav"))):
+        try:
+            ladder.append((float(os.path.splitext(os.path.basename(p))[0].split("-")[-1].rstrip("s")), p))
+        except ValueError:
+            continue
+    if args.only:
+        wanted = {float(x) for x in args.only.split(",")}
+        ladder = [(s, p) for s, p in ladder if s in wanted]
+    if not ladder:
+        sys.exit("no clips selected")
+
+    print(f"clips         {len(ladder)}   repeats {args.repeats}   = {len(ladder) * args.repeats} uploads")
+    print(f"cleanup       {'NO - recordings kept' if args.keep else 'yes - recordings deleted after'}")
+    print("note          each upload may also spend the owner's summary/actions/tags LLM calls\n")
+
+    header = f"{'clip':>7} {'proc':>8} {'xRT':>7} {'queue':>8} {'wall':>8} {'segs':>5}"
+    print(header)
+    print("-" * len(header))
+
+    results, created = [], []
+    for secs, path in ladder:
+        runs = []
+        for _ in range(args.repeats):
+            r = measure(base, token, path, secs, args.timeout)
+            if r.get("id"):
+                created.append(r["id"])
+            if r.get("error"):
+                print(f"{secs:>6.0f}s   ERROR  {r['error']}")
+                continue
+            runs.append(r)
+        procs = [r["processing_s"] for r in runs if r["processing_s"] is not None]
+        if not procs:
+            continue
+        med = statistics.median(procs)
+        xrt = med / secs
+        q = statistics.median([r["queue_s"] for r in runs if r["queue_s"] is not None] or [0])
+        w = statistics.median([r["wall_s"] for r in runs])
+        flag = "  <-- SLOWER THAN REALTIME" if xrt >= 1.0 else ""
+        print(f"{secs:>6.0f}s {med:>7.2f}s {xrt:>6.2f}x {q:>7.1f}s {w:>7.1f}s "
+              f"{runs[0]['segments']:>5}{flag}")
+        results.append({"clip_seconds": secs, "processing_median_s": med,
+                        "processing_min_s": min(procs), "processing_max_s": max(procs),
+                        "realtime_factor": xrt, "queue_median_s": q, "wall_median_s": w,
+                        "segments": runs[0]["segments"], "speakers": runs[0]["speakers"]})
+
+    if not args.keep and created:
+        print(f"\ncleaning up {len(created)} test recordings...")
+        removed = sum(1 for rid in created
+                      if _client.request("DELETE", f"{base}/api/recordings/{rid}", token, timeout=60)[0]
+                      in (200, 204))
+        print(f"deleted {removed}/{len(created)}")
+        if removed != len(created):
+            print("run cleanup.py to remove the rest")
+
+    if len(results) >= 2:
+        # Shares chunk_floor's caveat: a negative floor means the ladder has a step change.
+        xs = [r["clip_seconds"] for r in results]
+        ys = [r["processing_median_s"] for r in results]
+        n = len(xs)
+        mx, my = sum(xs) / n, sum(ys) / n
+        denom = sum((x - mx) ** 2 for x in xs)
+        slope = sum((x - mx) * (y - my) for x, y in zip(xs, ys)) / denom if denom else 0.0
+        floor = my - slope * mx
+        print("\n" + "=" * 62)
+        print(f"fixed floor per job   {floor:6.2f} s  (paid regardless of chunk length)")
+        if slope > 0:
+            print(f"marginal cost         {slope:6.3f} s per second of audio ({1 / slope:.2f}x realtime)")
+        print()
+        for target in (20, 30, 45, 60):
+            pred = floor + slope * target
+            verdict = "KEEPS UP" if pred < target * 0.8 else ("TIGHT" if pred < target else "FALLS BEHIND")
+            print(f"  {target:>2}s chunk -> {pred:5.1f}s   {(target - pred) / target * 100:+6.1f}% headroom   {verdict}")
+        print("\nPrefer a measured row over the fit where one exists - the fit is least accurate")
+        print("in the middle of the ladder, which is exactly where the live chunk sizes are.")
+
+    if args.json_out:
+        with open(args.json_out, "w") as f:
+            json.dump(results, f, indent=2)
+        print(f"\nraw results -> {args.json_out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/transcription-bench/chunk_floor.py
+++ b/tools/transcription-bench/chunk_floor.py
@@ -1,0 +1,232 @@
+"""Measure the per-chunk floor of the transcription pipeline, stage by stage.
+
+Answers one question: as a clip gets shorter, what does the per-job cost converge to? That
+fixed floor decides whether live chunked transcription can keep up with a meeting, because a
+30 s chunk costing 45 s of wall clock falls behind without bound.
+
+Run INSIDE the worker container, where the models are cached and the GPU is attached:
+
+    docker cp clips           <worker>:/tmp/clips
+    docker cp chunk_floor.py  <worker>:/tmp/chunk_floor.py
+    docker exec -it <worker> python3 /tmp/chunk_floor.py /tmp/clips
+
+(run-local.ps1 does all of that against a locally-built image.)
+
+It replicates pipeline.transcribe() stage by stage rather than calling it, so each stage is
+timed separately. Nothing is written back to the API and no job queue is touched - this reads
+the models and nothing else.
+
+See docs/Streaming_Capture_and_Live_Transcript.md section 3 for measured results.
+"""
+import argparse
+import glob
+import json
+import os
+import statistics
+import sys
+import time
+
+sys.path.insert(0, "/app")
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+# The same two shims worker.py applies before touching torch, in the same order. This script
+# bypasses worker.py, so without them the pyannote VAD checkpoint fails to load on torch>=2.6
+# ("Weights only load failed ... Unsupported global") and an empty HSA_OVERRIDE_GFX_VERSION
+# silently drops a ROCm box to CPU. Both are easy to lose and hard to diagnose.
+import rocm_env  # noqa: E402
+
+rocm_env.clean_gfx_override()
+
+import torch_compat  # noqa: E402
+
+torch_compat.restore_legacy_torch_load()
+
+import whisperx  # noqa: E402
+import pipeline  # noqa: E402
+from config import config  # noqa: E402
+
+STAGES = ["decode", "asr", "align", "diarize", "shape", "embeddings"]
+
+
+class Timer:
+    """Accumulates stage timings for one pass."""
+
+    def __init__(self) -> None:
+        self.stages: dict[str, float] = {}
+
+    def time(self, name: str, fn):
+        t0 = time.perf_counter()
+        result = fn()
+        self.stages[name] = time.perf_counter() - t0
+        return result
+
+    @property
+    def total(self) -> float:
+        return sum(self.stages.values())
+
+
+def one_pass(path: str) -> tuple[Timer, dict]:
+    """One full pipeline pass over a clip, timed per stage. Mirrors pipeline.transcribe()."""
+    t = Timer()
+
+    audio = t.time("decode", lambda: whisperx.load_audio(path))
+    duration_ms = pipeline._duration_ms(audio)
+
+    asr = t.time("asr", lambda: pipeline._asr(audio, None))
+    language = asr["language"]
+
+    def do_align():
+        aligned = pipeline._get_align(language)
+        if aligned is None:
+            return {"segments": asr["segments"]}
+        model, meta = aligned
+        return whisperx.align(asr["segments"], model, meta, audio, config.DEVICE,
+                              return_char_alignments=False)
+
+    result = t.time("align", do_align)
+
+    def do_diarize():
+        diar = pipeline._diarize(audio, None, None)
+        return whisperx.assign_word_speakers(diar, result)
+
+    result = t.time("diarize", do_diarize)
+    segments = t.time("shape", lambda: pipeline._shape_segments(result["segments"]))
+    speakers = t.time("embeddings", lambda: pipeline._extract_speakers(audio, segments))
+
+    return t, {"duration_ms": duration_ms, "segments": len(segments),
+               "speakers": len(speakers or []), "language": language}
+
+
+def clip_seconds(path: str) -> float:
+    """Length in seconds from a clip-NNNs.wav filename."""
+    stem = os.path.splitext(os.path.basename(path))[0]
+    return float(stem.split("-")[-1].rstrip("s"))
+
+
+def fit(xs: list[float], ys: list[float]) -> tuple[float, float]:
+    """Least-squares (intercept, slope). The intercept is the fixed per-job cost.
+
+    Only meaningful when the curve has no regime change. A GPU that runs out of memory
+    partway up the ladder produces a step, and fitting one line across it yields a negative
+    intercept - an artefact, not a floor. Read such a ladder row by row instead.
+    """
+    n = len(xs)
+    mx, my = sum(xs) / n, sum(ys) / n
+    denom = sum((x - mx) ** 2 for x in xs)
+    slope = sum((x - mx) * (y - my) for x, y in zip(xs, ys)) / denom if denom else 0.0
+    return my - slope * mx, slope
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("clips_dir")
+    ap.add_argument("--repeats", type=int, default=3,
+                    help="timed passes per clip (default 3; run-to-run noise is real)")
+    ap.add_argument("--json", dest="json_out", default=None, help="also write raw results here")
+    args = ap.parse_args()
+
+    paths = sorted(glob.glob(os.path.join(args.clips_dir, "*.wav")))
+    if not paths:
+        sys.exit(f"no .wav files in {args.clips_dir}")
+
+    print("=" * 78)
+    print("Diariz per-chunk floor measurement")
+    print("=" * 78)
+    print(f"device        {config.DEVICE}   compute {config.COMPUTE_TYPE}")
+    print(f"asr backend   {config.ASR_BACKEND}   model {config.WHISPER_MODEL}   batch {config.BATCH_SIZE}")
+    print(f"embeddings    {'on' if config.ENABLE_SPEAKER_EMBEDDINGS else 'OFF'}")
+    try:
+        import torch
+        if torch.cuda.is_available():
+            print(f"gpu           {torch.cuda.get_device_name(0)}  "
+                  f"{torch.cuda.get_device_properties(0).total_memory / 1e9:.1f} GB")
+    except Exception:  # noqa: BLE001 - a missing/!CUDA torch must not abort the run
+        pass
+    print(f"clips         {len(paths)}   repeats {args.repeats}")
+    print()
+
+    print("warming models (cold start, reported separately)...", flush=True)
+    t0 = time.perf_counter()
+    one_pass(paths[0])
+    cold = time.perf_counter() - t0
+    print(f"cold first pass: {cold:.1f}s   <- what a second worker process pays once at boot\n")
+
+    header = f"{'clip':>7} {'total':>8} {'xRT':>6} " + " ".join(f"{s:>9}" for s in STAGES) + f" {'segs':>5}"
+    print(header)
+    print("-" * len(header))
+
+    results = []
+    for path in paths:
+        secs = clip_seconds(path)
+        runs, meta = [], {}
+        for _ in range(args.repeats):
+            t, meta = one_pass(path)
+            runs.append(t)
+
+        totals = [t.total for t in runs]
+        median_total = statistics.median(totals)
+        med = {s: statistics.median([t.stages[s] for t in runs]) for s in STAGES}
+        xrt = median_total / secs
+
+        flag = "  <-- SLOWER THAN REALTIME" if xrt >= 1.0 else ""
+        print(f"{secs:>6.0f}s {median_total:>7.2f}s {xrt:>5.2f}x " +
+              " ".join(f"{med[s]:>8.2f}s" for s in STAGES) +
+              f" {meta['segments']:>5}{flag}")
+
+        results.append({
+            "clip_seconds": secs,
+            "total_median_s": median_total,
+            "total_min_s": min(totals),
+            "total_max_s": max(totals),
+            "spread_pct": (max(totals) - min(totals)) / median_total * 100 if median_total else 0,
+            "realtime_factor": xrt,
+            "stages_median_s": med,
+            "segments": meta.get("segments"),
+            "speakers": meta.get("speakers"),
+        })
+
+    print()
+    print("=" * 78)
+    print("Interpretation")
+    print("=" * 78)
+
+    floor, slope = fit([r["clip_seconds"] for r in results], [r["total_median_s"] for r in results])
+    print(f"fixed floor per job     {floor:6.2f} s   (paid by every chunk regardless of length)")
+    if slope > 0:
+        print(f"marginal cost           {slope:6.3f} s per second of audio  ({1 / slope:.2f}x realtime)")
+    if floor < 0:
+        print("  NOTE: a negative floor means the ladder has a step change (typically a GPU running")
+        print("  out of memory partway up). The fit is invalid here - read the rows individually.")
+    print()
+
+    for target in (20, 30, 45, 60):
+        predicted = floor + slope * target
+        verdict = "KEEPS UP" if predicted < target * 0.8 else ("TIGHT" if predicted < target else "FALLS BEHIND")
+        print(f"  {target:>2}s chunk -> {predicted:5.1f}s to process   "
+              f"{(target - predicted) / target * 100:+6.1f}% headroom   {verdict}")
+
+    print()
+    spreads = [r["spread_pct"] for r in results]
+    print(f"run-to-run spread: median {statistics.median(spreads):.0f}%, worst {max(spreads):.0f}%")
+    print("A chunk size only works if it keeps up at the WORST observed time, not the median.")
+    print("Clips under ~20 s of this ladder contain one speaker, so their diarization cost is")
+    print("unrepresentative of a real chunk - size against the 20 s row, not the 15 s one.")
+
+    if args.json_out:
+        with open(args.json_out, "w") as f:
+            json.dump({
+                "config": {
+                    "device": config.DEVICE, "compute": config.COMPUTE_TYPE,
+                    "backend": config.ASR_BACKEND, "model": config.WHISPER_MODEL,
+                    "batch_size": config.BATCH_SIZE,
+                    "embeddings": bool(config.ENABLE_SPEAKER_EMBEDDINGS),
+                },
+                "cold_start_s": cold,
+                "results": results,
+                "fit": {"floor_s": floor, "slope_s_per_s": slope},
+            }, f, indent=2)
+        print(f"\nraw results -> {args.json_out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/transcription-bench/cleanup.py
+++ b/tools/transcription-bench/cleanup.py
@@ -1,0 +1,52 @@
+"""Find and remove ONLY the recordings this benchmark created.
+
+api_floor.py deletes its own recordings on a clean exit. This exists for the case it did not:
+an interrupted run, a network failure mid-cleanup, or --keep.
+
+Matching is on Recording.Title, which the bench sets to "floor-bench <n>s". Never on Name: the
+summariser overwrites Name with a generated title (and will happily invent a plausible-looking
+meeting name for synthetic audio), so a name-based filter stops matching the moment
+summarisation runs. Title is the auto descriptor and stays stable.
+
+    DIARIZ_TOKEN=dz_api_... python cleanup.py --base http://host:8080            # dry run
+    DIARIZ_TOKEN=dz_api_... python cleanup.py --base http://host:8080 --delete
+"""
+import argparse
+
+import _client
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    _client.add_common_args(ap)
+    ap.add_argument("--delete", action="store_true", help="actually delete (default is a dry run)")
+    args = ap.parse_args()
+    base, token = _client.resolve(args)
+
+    everything = _client.list_recordings(base, token)
+    mine = [r for r in everything if str(r.get("title", "")).startswith(_client.MARKER)]
+    print(f"{len(everything)} recordings on the instance; "
+          f"{len(mine)} match title prefix {_client.MARKER!r}\n")
+    for r in mine:
+        print(f"  {r['id']}  {str(r.get('createdAt'))[:19]}  {r.get('title')}  (name: {r.get('name')})")
+
+    if not mine:
+        print("nothing to do.")
+        return
+    if not args.delete:
+        print(f"\ndry run - pass --delete to remove these {len(mine)}.")
+        return
+
+    print(f"\ndeleting {len(mine)}...")
+    ok = 0
+    for r in mine:
+        status, body = _client.request("DELETE", f"{base}/api/recordings/{r['id']}", token)
+        if status in (200, 204):
+            ok += 1
+        else:
+            print(f"  FAILED {r['id']}: HTTP {status} {str(body)[:120]}")
+    print(f"deleted {ok}/{len(mine)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/transcription-bench/make-audio.ps1
+++ b/tools/transcription-bench/make-audio.ps1
@@ -1,0 +1,81 @@
+# Generates a synthetic two-speaker "meeting" WAV (16 kHz, 16-bit, mono) using Windows TTS.
+#
+# The content is entirely invented and the voices are synthetic, so nothing here touches real
+# recordings - which is the point: benchmark material must never be production audio.
+#
+# Two alternating voices with varied speaking rate give the diarizer real work to do. Note the
+# consequence measured in docs/Streaming_Capture_and_Live_Transcript.md section 3.3: the opening
+# turns are long, so clips shorter than ~20 s contain ONE speaker and are therefore much cheaper
+# than a real chunk. Read the 20 s row, not the 15 s one.
+#
+#   .\make-audio.ps1                 # writes base.wav beside this script
+#   .\make-audio.ps1 -Out other.wav
+
+param([string] $Out = "")
+
+$ErrorActionPreference = "Stop"
+Add-Type -AssemblyName System.Speech
+
+if (-not $Out) { $Out = Join-Path $PSScriptRoot "base.wav" }
+
+# Invented dialogue - fictional company, fictional people, fictional numbers.
+$turns = @(
+  @{ v = "Hazel"; r = 0;  t = "Right, shall we make a start. The agenda today is the Northwind rollout, the warehouse integration, and then whatever is left over from last fortnight." },
+  @{ v = "Zira";  r = 1;  t = "Sounds good. I have got the numbers from the pilot region if you want to take those first, because they change how we think about the second phase quite a lot." },
+  @{ v = "Hazel"; r = 0;  t = "Go on then, let us have them." },
+  @{ v = "Zira";  r = 1;  t = "So across the four pilot depots we processed about eleven thousand consignments in six weeks. The scanning accuracy came out at ninety four percent, which is below the target of ninety eight, but the failures cluster almost entirely in one depot." },
+  @{ v = "Hazel"; r = -1; t = "Which depot, and do we know why." },
+  @{ v = "Zira";  r = 1;  t = "The northern one. And yes, we think so. They are running the older handheld units, and the firmware on those does not do the retry loop properly. When a barcode is damp or creased it gives up after a single attempt instead of trying three times." },
+  @{ v = "Hazel"; r = 0;  t = "That is a hardware refresh then, not a software problem. How many units are we talking about and what does that cost us." },
+  @{ v = "Zira";  r = 0;  t = "About sixty units. The replacement is roughly two hundred and forty pounds each, so call it fifteen thousand all in, plus a day of training per shift. It is not nothing but it is well inside the contingency we set aside in March." },
+  @{ v = "Hazel"; r = 1;  t = "Fine. Let us book that in for next month rather than trying to squeeze it into this one. Put it on the risk register in the meantime so nobody is surprised when the accuracy figures look poor in the next report." },
+  @{ v = "Zira";  r = 0;  t = "Will do. The second thing is the warehouse integration. We have got the connector working in the test environment, but it is slower than we expected under load." },
+  @{ v = "Hazel"; r = 0;  t = "Slower in what way. Is it the network or is it the processing." },
+  @{ v = "Zira";  r = 1;  t = "It is the processing, and specifically it is the reconciliation step. Every time a pallet is checked in, the connector re-reads the entire manifest rather than just the delta. On a small manifest you never notice. On a two thousand line manifest it takes about forty seconds." },
+  @{ v = "Hazel"; r = -1; t = "Forty seconds is far too long. What happens to the operator while that is running." },
+  @{ v = "Zira";  r = 1;  t = "They wait, which is the problem. In the pilot they started working around it by batching all the check-ins to the end of the shift, which completely defeats the point of having live stock levels in the first place." },
+  @{ v = "Hazel"; r = 0;  t = "So we have built something that people are actively avoiding using. That is worth saying out loud." },
+  @{ v = "Zira";  r = 0;  t = "It is, and I do not think it is hard to fix. The delta logic already exists on the ingest side, it was just never wired into the reconciliation path. I would guess a week of work and a fortnight of testing." },
+  @{ v = "Hazel"; r = 1;  t = "Then let us do that before we widen the rollout at all. There is no sense putting a slow tool in front of another two hundred people. Who is picking that up." },
+  @{ v = "Zira";  r = 0;  t = "I will take it, unless you want it to go to the platform team. They wrote the original ingest code so they know it better than I do." },
+  @{ v = "Hazel"; r = 0;  t = "Give it to them, but stay close to it. You are the one who found it and you understand the operational side, which they do not." },
+  @{ v = "Zira";  r = 1;  t = "Fair enough. Last item then, the leftovers from last time. The training materials are done and signed off. The depot manager handbook is still in draft because we are waiting on the legal review of the data retention section." },
+  @{ v = "Hazel"; r = -1; t = "How long have we been waiting on that." },
+  @{ v = "Zira";  r = 0;  t = "Three weeks now. I chased it last Tuesday and got an acknowledgement but no date." },
+  @{ v = "Hazel"; r = 0;  t = "I will chase that myself, I know the person. Anything else before we finish." },
+  @{ v = "Zira";  r = 1;  t = "Only that the second phase kick-off is provisionally the twelfth, and I would like to move it back a fortnight given what we have just said about the connector. There is no point starting phase two with a known performance problem." },
+  @{ v = "Hazel"; r = 0;  t = "Agreed, move it. Send a note round explaining why, because people have already booked travel and they will want a reason rather than just a new date." },
+  @{ v = "Zira";  r = 0;  t = "Understood. I will get that out this afternoon." },
+  @{ v = "Hazel"; r = 0;  t = "Good. Thank you both, that was quicker than I expected. Let us pick this up again in a fortnight." },
+  @{ v = "Zira";  r = 1;  t = "One more thing actually, sorry. Do we need to tell the finance team about the handheld replacement, or does that come out of the budget we already hold." },
+  @{ v = "Hazel"; r = 0;  t = "It comes out of the contingency, so no approval needed, but tell them anyway as a courtesy. They dislike finding out about spend from the quarterly report." },
+  @{ v = "Zira";  r = 0;  t = "Right, I will copy them in on the same note. That is everything from me." },
+  @{ v = "Hazel"; r = 0;  t = "Then we are done. Thanks everyone." }
+)
+
+# 16 kHz mono matches what whisperx.load_audio resamples to, so the ladder costs the decoder nothing.
+$fmt = New-Object System.Speech.AudioFormat.SpeechAudioFormatInfo(16000, `
+  [System.Speech.AudioFormat.AudioBitsPerSample]::Sixteen, `
+  [System.Speech.AudioFormat.AudioChannel]::Mono)
+
+$synth = New-Object System.Speech.Synthesis.SpeechSynthesizer
+$synth.SetOutputToWaveFile($Out, $fmt)
+
+$voices = $synth.GetInstalledVoices()
+foreach ($turn in $turns) {
+  $match = $voices | Where-Object { $_.VoiceInfo.Name -like "*$($turn.v)*" } | Select-Object -First 1
+  if (-not $match) { throw "TTS voice '$($turn.v)' is not installed. Installed: $(($voices | ForEach-Object { $_.VoiceInfo.Name }) -join ', ')" }
+  $synth.SelectVoice($match.VoiceInfo.Name)
+  $synth.Rate = $turn.r
+  $synth.Speak($turn.t)
+}
+
+$synth.SetOutputToNull()
+$synth.Dispose()
+
+$len = (Get-Item $Out).Length
+Write-Output "wrote $Out"
+Write-Output "bytes: $len"
+Write-Output "approx seconds: $([math]::Round(($len - 44) / 32000.0, 1))"
+Write-Output ""
+Write-Output "next: python slice.py"

--- a/tools/transcription-bench/run-local.ps1
+++ b/tools/transcription-bench/run-local.ps1
@@ -1,0 +1,67 @@
+# Builds the worker image (if needed) and runs chunk_floor.py inside it against the clip ladder.
+#
+# Reads HF_TOKEN out of deploy/.env without echoing it. Models are cached in a named volume, so
+# the first run downloads several GB and later runs start warm.
+#
+#   .\run-local.ps1 -Build                      # build the image first
+#   .\run-local.ps1                             # full ladder, 3 repeats
+#   .\run-local.ps1 -ClipsDir clips-smoke -Repeats 1
+#
+# On a card with limited VRAM, drop -BatchSize. An 8 GB card runs the pipeline but is memory-bound
+# and cannot sustain realtime (see docs/Streaming_Capture_and_Live_Transcript.md section 3.3).
+
+param(
+  [string] $ClipsDir  = "clips",
+  [int]    $Repeats   = 3,
+  [int]    $BatchSize = 16,
+  [string] $Model     = "large-v3",
+  [string] $JsonOut   = "",
+  [string] $EnvFile   = "",
+  [string] $Image     = "diariz-worker:bench",
+  [switch] $Build
+)
+
+$ErrorActionPreference = "Stop"
+
+$here     = $PSScriptRoot
+$repoRoot = (Resolve-Path (Join-Path $here "..\..")).Path
+if (-not $EnvFile) { $EnvFile = Join-Path $repoRoot "deploy\.env" }
+
+if (-not (Test-Path $EnvFile)) { throw "env file not found: $EnvFile (copy deploy\.env.example)" }
+$hf = (Get-Content $EnvFile | Where-Object { $_ -match '^\s*HF_TOKEN\s*=' } |
+       Select-Object -First 1) -replace '^\s*HF_TOKEN\s*=\s*', ''
+if (-not $hf) { throw "HF_TOKEN is not set in $EnvFile - pyannote diarization cannot load without it" }
+
+$clips = Join-Path $here $ClipsDir
+if (-not (Test-Path $clips)) { throw "no such clips dir: $clips (run make-audio.ps1 then slice.py)" }
+
+if ($Build) {
+  Write-Output "building $Image from src\Diariz.Worker ..."
+  docker build -t $Image (Join-Path $repoRoot "src\Diariz.Worker")
+  if ($LASTEXITCODE -ne 0) { throw "docker build failed" }
+}
+
+# $dockerArgs, not $args - $args is an automatic variable in PowerShell.
+$dockerArgs = @(
+  "run", "--rm", "--gpus", "all",
+  "-e", "HF_TOKEN=$hf",
+  "-e", "DEVICE=cuda",
+  "-e", "COMPUTE_TYPE=float16",
+  "-e", "BATCH_SIZE=$BatchSize",
+  "-e", "WHISPER_MODEL=$Model",
+  "-e", "ENABLE_SPEAKER_EMBEDDINGS=1",
+  "-e", "ASR_BACKEND=whisperx",
+  "-v", "diariz-bench-cache:/root/.cache",
+  "-v", "${clips}:/clips:ro",
+  "-v", "$here\chunk_floor.py:/bench/chunk_floor.py:ro",
+  "-v", "${here}:/out"
+)
+$inner = "python3 /bench/chunk_floor.py /clips --repeats $Repeats"
+if ($JsonOut) { $inner += " --json /out/$JsonOut" }
+# Model downloads and whisperx emit progress bars on stderr; keep the summary readable by
+# writing everything to a log inside the container and printing the filtered tail.
+$dockerArgs += @($Image, "sh", "-c", "$inner > /tmp/bench.log 2>&1; grep -v 'B/s\]\|it/s\]' /tmp/bench.log | tail -50")
+
+Write-Output "clips=$ClipsDir repeats=$Repeats batch=$BatchSize model=$Model"
+& docker @dockerArgs
+if ($LASTEXITCODE -ne 0) { throw "benchmark run failed (exit $LASTEXITCODE)" }

--- a/tools/transcription-bench/slice.py
+++ b/tools/transcription-bench/slice.py
@@ -1,0 +1,57 @@
+"""Slice base.wav into the duration ladder used by the per-chunk floor measurement.
+
+Pure stdlib (wave), so it runs anywhere without ffmpeg. Every clip is a contiguous window
+taken from the same offset, so length is the only variable across the ladder - which is what
+lets a linear fit separate the fixed per-job floor from the marginal cost per second.
+
+    python slice.py                       # base.wav -> clips/
+    python slice.py --src other.wav --out other-clips
+"""
+import argparse
+import os
+import wave
+
+# Short end probes the fixed floor; the long end anchors the slope.
+DURATIONS = [5, 10, 15, 20, 30, 45, 60, 90, 120, 180, 240]
+
+# Start a little way in so every clip opens mid-speech rather than on the synthesiser's
+# leading silence, which would otherwise make the shortest clips mostly quiet.
+OFFSET_S = 2.0
+
+
+def main() -> None:
+    here = os.path.dirname(os.path.abspath(__file__))
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--src", default=os.path.join(here, "base.wav"))
+    ap.add_argument("--out", default=os.path.join(here, "clips"))
+    args = ap.parse_args()
+
+    with wave.open(args.src, "rb") as src:
+        ch, width = src.getnchannels(), src.getsampwidth()
+        rate, frames = src.getframerate(), src.getnframes()
+        total_s = frames / rate
+        print(f"source: {ch}ch {width * 8}bit {rate}Hz  {total_s:.1f}s  ({frames} frames)")
+        src.setpos(int(OFFSET_S * rate))
+        body = src.readframes(frames - int(OFFSET_S * rate))
+
+    os.makedirs(args.out, exist_ok=True)
+    written = 0
+    for secs in DURATIONS:
+        want = int(secs * rate) * ch * width
+        if want > len(body):
+            print(f"  skip {secs:>4}s - source is only {total_s - OFFSET_S:.1f}s after the offset")
+            continue
+        path = os.path.join(args.out, f"clip-{secs:03d}s.wav")
+        with wave.open(path, "wb") as dst:
+            dst.setnchannels(ch)
+            dst.setsampwidth(width)
+            dst.setframerate(rate)
+            dst.writeframes(body[:want])
+        print(f"  clip-{secs:03d}s.wav  {os.path.getsize(path) / 1024:8.1f} KiB")
+        written += 1
+
+    print(f"\n{written} clips in {args.out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/transcription-bench/speakers.py
+++ b/tools/transcription-bench/speakers.py
@@ -1,0 +1,43 @@
+"""Confirm diarization actually ran on the benchmark recordings.
+
+Worth running whenever comparing two boxes. If the fast one were silently skipping
+diarization - the most expensive stage, 75-80% of a chunk - every segment would land on one
+label and the timing comparison would be meaningless. This shows the label distribution so
+that failure is visible rather than assumed away.
+
+    DIARIZ_TOKEN=dz_api_... python speakers.py --base http://host:8080
+
+Only reports on recordings this benchmark created (title prefix "floor-bench"), so it never
+prints anything about real recordings.
+"""
+import argparse
+import collections
+
+import _client
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    _client.add_common_args(ap)
+    args = ap.parse_args()
+    base, token = _client.resolve(args)
+
+    mine = _client.bench_recordings(base, token)
+    if not mine:
+        raise SystemExit(f"no {_client.MARKER!r} recordings present right now")
+
+    print(f"{'title':<20} {'segs':>5} {'labels':>7}  distribution")
+    print("-" * 68)
+    for rec in mine:
+        status, d = _client.request("GET", f"{base}/api/recordings/{rec['id']}", token)
+        if status != 200:
+            print(f"{rec.get('title'):<20}  HTTP {status}")
+            continue
+        segs = (d.get("current") or {}).get("segments") or []
+        counts = collections.Counter(s.get("speakerLabel") or s.get("speaker") or "?" for s in segs)
+        warn = "   <-- single label, check diarization ran" if len(counts) < 2 and len(segs) > 3 else ""
+        print(f"{rec.get('title'):<20} {len(segs):>5} {len(counts):>7}  {dict(counts)}{warn}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/transcription-bench/validate.py
+++ b/tools/transcription-bench/validate.py
@@ -1,0 +1,81 @@
+"""Check the synthetic-clip fit against real recordings already on an instance.
+
+Synthetic TTS is cleaner than a real meeting - no overlap, no room noise, few speakers - so it
+could understate diarization cost. This compares the fit against audio that has actually been
+through the pipeline.
+
+Reports ONLY summary calculations: counts, ratios, percentiles. No names, no titles, no
+transcript text, nothing that identifies a recording or a person. Keep it that way - the repo
+is public and this is the one tool here that reads production data.
+
+    DIARIZ_TOKEN=dz_api_... python validate.py --base http://host:8080 --floor 1.26 --slope 0.029
+"""
+import argparse
+import statistics
+
+import _client
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    _client.add_common_args(ap)
+    ap.add_argument("--sample", type=int, default=60, help="how many recordings to inspect")
+    ap.add_argument("--min-seconds", type=float, default=30, help="ignore anything shorter")
+    ap.add_argument("--floor", type=float, required=True, help="fitted fixed cost, seconds")
+    ap.add_argument("--slope", type=float, required=True, help="fitted seconds per second of audio")
+    args = ap.parse_args()
+
+    base, token = _client.resolve(args)
+
+    items = [x for x in _client.list_recordings(base, token)
+             if (x.get("durationMs") or 0) > args.min_seconds * 1000]
+    # Longest first: those exercise the pipeline hardest and are the useful check.
+    items.sort(key=lambda x: -(x.get("durationMs") or 0))
+    items = items[:args.sample]
+    print(f"sampling {len(items)} real recordings over {args.min_seconds:.0f}s, longest first\n")
+
+    rows = []
+    for rec in items:
+        status, d = _client.request("GET", f"{base}/api/recordings/{rec['id']}", token)
+        if status != 200:
+            continue
+        cur = d.get("current") or {}
+        proc_ms, dur_ms = cur.get("processingMs"), d.get("durationMs") or 0
+        if not proc_ms or dur_ms <= 0:
+            continue
+        if (cur.get("model") or "") == "merged":
+            continue  # a concatenated transcript never went through the worker
+        rows.append({"dur_s": dur_ms / 1000.0, "proc_s": proc_ms / 1000.0,
+                     "xrt": proc_ms / dur_ms, "speakers": len(d.get("speakerNames") or {})})
+
+    if not rows:
+        raise SystemExit("no recordings with processingMs found (only newer transcriptions carry it)")
+
+    xrts = sorted(r["xrt"] for r in rows)
+    durs = sorted(r["dur_s"] for r in rows)
+    print(f"usable sample          {len(rows)} recordings")
+    print(f"audio length           median {statistics.median(durs) / 60:.1f} min, "
+          f"max {max(durs) / 60:.1f} min, total {sum(durs) / 3600:.1f} h")
+    print(f"speakers per recording median {statistics.median([r['speakers'] for r in rows]):.0f}, "
+          f"max {max(r['speakers'] for r in rows)}")
+    print()
+    print("realtime factor (processing time / audio length) - lower is faster")
+    print(f"  p10 {xrts[len(xrts) // 10]:.4f}   median {statistics.median(xrts):.4f}   "
+          f"p90 {xrts[len(xrts) * 9 // 10]:.4f}   worst {max(xrts):.4f}")
+    print()
+
+    predicted = [args.floor + args.slope * r["dur_s"] for r in rows]
+    optimistic = sum(1 for r, p in zip(rows, predicted) if r["proc_s"] > p)
+    ratio = statistics.median([r["proc_s"] / p for r, p in zip(rows, predicted)])
+    print(f"synthetic fit ({args.floor}s + {args.slope}s/s) vs real audio:")
+    print(f"  fit is optimistic for {optimistic}/{len(rows)} recordings")
+    print(f"  real audio is ~{ratio:.2f}x the synthetic cost at the same length")
+    print()
+    for target in (20, 30, 45, 60):
+        pred = (args.floor + args.slope * target) * ratio
+        print(f"  {target:>2}s chunk -> {pred:5.2f}s adjusted   "
+              f"{(target - pred) / target * 100:+5.1f}% headroom")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Specifies uploading a recording in chunks as the meeting runs, and transcribing those chunks into a provisional transcription version, so the transcript and chat are usable **during** the meeting rather than only after it.

New doc: `docs/Streaming_Capture_and_Live_Transcript.md`.

## The measurement that gated it

The design hung on one question: does a chunk cost materially less wall-clock time than its own duration? If a 30 s chunk cost 45 s, the backlog would grow without bound for the whole meeting - a broken feature, not a slow one.

Measured on the CUDA box (RTX 5090) through the real Redis queue, and validated against **58 real recordings totalling 73.5 h** (aggregate statistics only - no content, titles or participants):

| | |
|---|---|
| Fixed per-job floor | **1.26 s** |
| Marginal cost | 0.029 s per second of audio |
| A 30 s chunk | **2.67 s measured - 91% headroom** |
| Real meetings, median | 0.0205x realtime (~49x) |
| Real meetings, worst observed | 0.0482x (~21x) |

Three findings shape the spec:

- **Diarization is 75-80% of per-chunk cost.** ASR is a quarter; alignment and ECAPA are rounding errors.
- **Short clips are cheap for the wrong reason.** The 5-15 s clips are single-speaker, so pyannote has nothing to cluster. The step at 20 s is the second voice arriving, not a duration threshold - so chunk sizing must read the 20 s row, never the 15 s one.
- **An 8 GB GPU cannot do this.** An RTX 4070 Laptop sat at 95% VRAM, crossed 1.0x realtime at ~150 s and settled at 1.06x. That becomes a startup capability probe in the spec, not an operator flag someone discovers is wrong mid-meeting.

Both boxes produced identical segment counts and speaker labels at every clip length, so the comparison is like-for-like.

## A correction to an existing doc

`Overall_Synopsis_of_Platform.md`'s only recorded throughput figure - "~1.3-1.7x realtime for `large-v3`" - is **ROCm-only**, measured on the Strix Halo APU with the `openai-whisper` backend. It is 25-50x pessimistic for the CUDA deployment. This PR attributes it and records the CUDA numbers beside it.

That correction narrows this feature's rationale, and the spec says so plainly: a 60-minute meeting occupies the worker ~75 s, so the transcript already arrives about ninety seconds after Stop. **The entire value of this change is in-meeting use** - it does not meaningfully shorten the wait afterwards, and should not be argued for on that basis.

## Design shape

- Chunks are stored contiguous and non-overlapping so they concatenate into the canonical blob via the existing `audio-merge-jobs` path. Overlap is a property of the *decode window* - the worker prepends the previous chunk's tail and trims the result back - so seam quality costs nothing on disk.
- The live pass writes `Transcription.IsProvisional = true`. `RecordingsController.Get` already returns only the highest version, so the final pass supersedes it automatically. Nothing downstream (summary, minutes, actions, tags, embeddings, webhooks, exports) ever runs on provisional text.
- Cross-chunk speaker identity is stitched from the ECAPA vectors the pipeline already emits, matched against session centroids and the voiceprint directory. A live match never enrols.
- Five PRs, the first of which (streaming capture, no live transcript) is worth shipping alone: durability during the meeting, no upload cliff, and no more ~170 MB of Blobs held in the tab for a three-hour recording.

One spike (S0) gates implementation: whether byte-concatenated `MediaRecorder` fragments reproduce a decodable file across browsers, or whether the stop/restart-per-chunk fallback is needed.

## Release checklist

**Docs-only** - skips 1-3 (no version bump, no `RELEASES` entry, no `CAPABILITIES`/README/`features.md` edit, since nothing user-facing changes yet). Item 6 is done: `Overall_Synopsis_of_Platform.md` carries the throughput correction. `Data_Schema.md` is untouched - the schema changes are specified, not made.

**Deployment surface:** neither a desktop release nor a server redeploy. Documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)