### PR TITLE
Point the release checklist at the epoch-split release notes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,8 +32,10 @@ Full detail is in `CLAUDE.md`; these are the ones worth naming twice.
 - **TDD is required.** Write the failing test, watch it fail, then write the minimum to pass it.
 - **Never commit or push to `main`, and never merge locally.** Every change lands through a PR that
   passes CI. A bug fix opens a GitHub issue first, and the PR body closes it with `Fixes #<n>`.
-- **Every user-facing PR ships exactly one release**: bump `version.json` *and* its mirrors, and add one
-  `RELEASES[0]` entry. A docs-only PR skips the bump - say so in the PR body.
+- **Every user-facing PR ships exactly one release**: bump `version.json` *and* its seven mirrors, and add
+  one `RECENT[0]` entry to `apps/web/src/lib/releaseNotes/current.ts`. That is the only release-notes file
+  an ordinary PR touches - the rest of `lib/releaseNotes/` is the epoch layer over the archive, and
+  `archive.ts` must stay out of every eager module. A docs-only PR skips the bump - say so in the PR body.
 - **Never put production data in the repo.** No real names, email addresses, company names, recording
   titles or transcript text - in code, comments, **test fixtures**, docs, commit messages, issues or PRs.
   This repository is public. Invent fixture names (`Ada`, `Grace`, `Alice`); report findings from a live

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -223,8 +223,9 @@ the **PR body** - `Fixes #<n>` (or `Closes #<n>`) on its own line. Do this witho
 - Write the issue from the **user-visible symptom** (what went wrong, how to reproduce, what was expected), not
   from the fix you are about to write - it is the record of the bug, and the PR is the record of the fix.
 - **The issue consumes a number from the same sequence as PRs**, so the PR number is usually the issue number
-  + 1 - but confirm it rather than assuming (it feeds the `pr:` field in `apps/web/src/lib/releases.ts`, which
-  has to be written before `gh pr create` exists to report the real number).
+  + 1 - but confirm it rather than assuming (it feeds the `pr:` field in
+  `apps/web/src/lib/releaseNotes/current.ts`, which has to be written before `gh pr create` exists to
+  report the real number).
 - The closing keyword must be in the **PR body**; GitHub only auto-closes from the PR description or from a
   commit on the default branch, not from a PR title or a later comment. Verify the issue actually closed after
   the merge, and close it by hand if it did not.
@@ -244,15 +245,20 @@ is **Major.Minor.Build** (currently `0.x`).
   rewrites it and turns an unrelated dependency bump into a surprise version diff. Two of them sat at
   `0.197.4` for roughly sixty releases because the guard covered only the web one (issue #593).
   The web build injects the version (`__APP_VERSION__` via `vite.config.ts`/`vitest.config.ts`) and the API
-  reports it at `GET /health`. `RELEASES[0].version` in `apps/web/src/lib/releases.ts` **must equal**
-  `version.json` (asserted by `releases.test.ts`), and `versionMirrors.test.ts` asserts every mirror above.
-- **Add a release entry** to the top of `RELEASES` in `apps/web/src/lib/releases.ts` with: `version`,
-  `date`, `pr` (the GitHub PR number), `headline`, a **PR-level prose `summary`** (enough for a user to
-  understand the impact), and `added`/`changed`/`fixed` bullet lists as applicable.
-- **When the app's scope changes**, update the About-box `CAPABILITIES` summary in the same file (and
-  the disclaimers list in `apps/web/src/components/AboutModal.tsx` if a new third-party library/model
-  is introduced). `CAPABILITIES` is a **concise two-column markdown table** (`| Feature | Description |`,
-  one line per feature) — add/edit a row, don't reintroduce long prose (the About box renders it via
+  reports it at `GET /health`. `RECENT[0].version` in `apps/web/src/lib/releaseNotes/current.ts`
+  **must equal** `version.json` (asserted by `releaseNotes/releases.test.ts`), and `versionMirrors.test.ts`
+  asserts every mirror above.
+- **Add a release entry** to the top of `RECENT` in **`apps/web/src/lib/releaseNotes/current.ts`** with:
+  `version`, `date`, `pr` (the GitHub PR number), `headline`, a **PR-level prose `summary`** (enough for a
+  user to understand the impact), and `added`/`changed`/`fixed` bullet lists as applicable. **That file is
+  the only release-notes file an ordinary PR touches** - see "The release notes are epochs over an archive"
+  below for what the other four are and why you must not import them.
+- **When the app's scope changes**, update the About-box `CAPABILITIES` summary in
+  **`apps/web/src/lib/appInfo.ts`** - it moved there in 0.260.0 so the eager About box and Help pages
+  stop dragging the release history into the initial bundle - and the disclaimers list in
+  `apps/web/src/components/AboutModal.tsx` if a new third-party library/model is introduced.
+  `CAPABILITIES` is a **concise two-column markdown table** (`| Feature | Description |`, one line per
+  feature) — add/edit a row, don't reintroduce long prose (the About box renders it via
   `renderMarkdown`; `.chat-md` table CSS in `apps/web/src/index.css` styles it).
 - **Keep `README.md` current.** When a PR changes what the app does — a new user-facing feature, a stack
   change, or a shipped roadmap milestone — update the README in the same PR (it mirrors the
@@ -261,7 +267,65 @@ is **Major.Minor.Build** (currently `0.x`).
   **full prose** feature list. On a feature change, update **all three in lockstep**: the README Features
   table row, the matching `docs/features.md` bullet, and the About-box `CAPABILITIES` table row (plus
   **Architecture**/**Roadmap** in the README when relevant). The README deliberately does **not** carry a
-  version number (it would drift) — the version lives only in `version.json` / `releases.ts`.
+  version number (it would drift) — the version lives only in `version.json` / `releaseNotes/current.ts`.
+- **The release notes are epochs over an archive, and summarisation is additive.** As of 0.260.0
+  (PR #675) the history lives in `apps/web/src/lib/releaseNotes/`, split five ways, and **none of it is
+  in the initial bundle any more** - that is most of what the PR was for (-197 KB gzip, -22%). Nothing
+  enforces that but **who imports what**, which is why there is a test on the module graph itself.
+
+  | File | Holds | Ends up in |
+  |---|---|---|
+  | `current.ts` | `RECENT` - releases since the last closed epoch. **The file every PR edits.** | both release-notes chunks |
+  | `epochs.ts` | `EPOCHS` (the named spans) + `ARCHIVED_SPINE` (version+date for every archived release) | both release-notes chunks |
+  | `epochSpan.ts` | derives an epoch's release count and date span from the spine | summary-page chunk |
+  | `archive.ts` | `ARCHIVE` - every release already covered by an epoch, ~170 KB gzip | **drill-down chunk only** |
+  | `index.ts` | barrel: types + `RECENT`. Deliberately does **not** re-export `ARCHIVE` | - |
+
+  Both pages (`pages/ReleaseNotes.tsx`, `pages/EpochDetail.tsx`) are `lazy()` routes in `App.tsx`, and
+  nothing eager imports `lib/releaseNotes` at all. The About box and Help read `lib/appInfo.ts` instead,
+  which is why `CAPABILITIES` lives there and not with the releases.
+
+  The page opens on the epoch cards, newest first, with an open "current" card for `RECENT`; clicking one
+  lists **every release in that span verbatim**. So an epoch summary is a *chapter heading over an intact
+  archive*, never a rewrite of it - nothing is merged, condensed, or dropped, and the drill-down is
+  lossless. If you ever find yourself editing an existing `Release` entry to make an epoch summary read
+  better, you have the direction backwards.
+
+  Four rules that are invisible when broken:
+  - **Only `pages/EpochDetail.tsx` may import `./archive`**, and the barrel must not re-export it. Adding
+    `import { ARCHIVE }` to any eager module type-checks, renders correctly, and passes every other test
+    while putting the whole history back on every page load. `bundleBoundary.test.ts` asserts the module
+    graph directly, because nothing else would catch it.
+  - **The epoch ranges must tile the archive** - every archived release in exactly one epoch, no gaps, no
+    overlaps. A release falling between two epochs is simply never listed: no 404, no error. `epochs.test.ts`
+    asserts this as **one equality over the whole archive**; per-epoch checks are the trap, since every
+    epoch can be well-formed while the set leaves a hole.
+  - **`ARCHIVED_SPINE` must mirror `ARCHIVE` exactly**, in the same order. It exists so the summary page can
+    derive counts and date spans without loading the archive. An epoch stores **no** count or date span -
+    both are derived (`epochSpan`), because a stored copy would be a second derivation agreeing only by luck.
+  - **`current` is a reserved epoch id** (`OPEN_EPOCH_ID`), serving `/release-notes/current`. A real epoch
+    taking it would silently shadow the newest releases.
+
+  The directory is `releaseNotes/`, **not** `releases/`: `.gitignore` carries the Visual Studio rule
+  `[Rr]eleases/`, which would silently omit the whole directory from the commit while everything still
+  built and passed locally.
+
+- **Closing an epoch is a deliberate, separate PR - not something an ordinary release PR does.** Leave
+  `RECENT` growing; `releases.test.ts` fails above 80 entries, but that is a safety net, not the trigger.
+  Close one when an **arc of work finishes** (the historical 30 epochs average ~16 releases, range 6-25),
+  which is a judgement about narrative, not a count - so **ask the user** rather than closing one
+  unprompted. Boundaries are chosen by **theme**, never by version or date: the minor version bumps on
+  nearly every release, and the cadence is a flat 30-50 releases a week, so either would cut arcs in half.
+  An epoch is a narrative, not a taxonomy - its range may contain a release its summary never mentions,
+  which is fine precisely because the drill-down is lossless. To close one:
+  1. Add the `Epoch` record at the **top** of `EPOCHS` in `epochs.ts` (`id`, `title`, `from`, `to`,
+     prose `summary`; `from`/`to` are **inclusive** version bounds).
+  2. Move those entries from `current.ts` to the **top** of `archive.ts`, unchanged and in order.
+  3. Extend `ARCHIVED_SPINE` with the same `{ version, date }` pairs, in the same order.
+
+  Get the order wrong between (2) and (3) and `epochs.test.ts` catches it; skip (3) entirely and the epoch
+  card renders with a count of zero.
+
 - **User help articles are NOT a fourth sync target.** `apps/web/src/content/help/**` is task-oriented
   "how do I / what happens if" prose written for a user inside the app; the README table,
   `docs/features.md`, and `CAPABILITIES` are *inventories* of what exists. Different genres, deliberately
@@ -303,8 +367,8 @@ is **Major.Minor.Build** (currently `0.x`).
      by hand rather than regenerating them; regenerating churns dependency resolution for no reason.
      `apps/web/src/lib/versionMirrors.test.ts` fails the build if any of them drifts - it exists because the
      n8n node silently sat at `0.1.0` for ~70 releases, and an npm version cannot be corrected once published.
-  2. The `RELEASES[0]` entry in `apps/web/src/lib/releases.ts` (must equal `version.json`).
-  3. The About-box **`CAPABILITIES`** table row in `releases.ts` (on a scope change) + `AboutModal.tsx`
+  2. The `RECENT[0]` entry in `apps/web/src/lib/releaseNotes/current.ts` (must equal `version.json`).
+  3. The About-box **`CAPABILITIES`** table row in `appInfo.ts` (on a scope change) + `AboutModal.tsx`
      disclaimers (on a new third-party library/model).
   4. The **README Features** table row.
   5. The **`docs/features.md`** prose bullet - the canonical full feature list; **always** update it alongside
@@ -321,8 +385,8 @@ is **Major.Minor.Build** (currently `0.x`).
   **exploratory side project**: repurposing the device for offline ambient capture that is later uploaded to
   Diariz. It is not built, tested, shipped, or referenced by any Diariz deployable. So a PR that **only**
   touches `omi/**` (including `omi/firmware/docs/**`):
-  - does **not** bump `version.json` or any mirror, and adds **no** `RELEASES` entry;
-  - is **not** mentioned in `releases.ts` `CAPABILITIES`, `AboutModal.tsx`, `README.md`,
+  - does **not** bump `version.json` or any mirror, and adds **no** `RECENT` entry;
+  - is **not** mentioned in `appInfo.ts` `CAPABILITIES`, `AboutModal.tsx`, `README.md`,
     `docs/features.md`, `docs/Overall_Synopsis_of_Platform.md`, `docs/Data_Schema.md`, or
     `apps/web/src/content/help/**`;
   - documents itself inside **`omi/firmware/docs/`** only.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,11 +33,19 @@ Every PR ships exactly one release: **bump the version and add one release-notes
 
 - Scheme is `Major.Minor.Build`. A **functional enhancement** bumps Minor +1 and resets Build to 0; any
   other PR (fix / chore / docs / refactor) bumps Build +1. Only bump Major when explicitly asked.
-- The canonical version is [`version.json`](version.json). Bump it in lockstep with its mirrors:
-  `apps/web/package.json`, `apps/desktop/package.json` (and their lock files), and
-  `src/Diariz.Api/Diariz.Api.csproj` (`<Version>`).
-- Add an entry to the top of `RELEASES` in [`apps/web/src/lib/releases.ts`](apps/web/src/lib/releases.ts);
-  `RELEASES[0].version` **must equal** `version.json` (a test asserts this).
+- The canonical version is [`version.json`](version.json). Bump it in lockstep with its **seven** mirrors:
+  `apps/web/package.json`, `apps/desktop/package.json`, `integrations/n8n-nodes-diariz/package.json`,
+  `src/Diariz.Api/Diariz.Api.csproj` (`<Version>`), and all three `package-lock.json` files - web, desktop
+  and n8n - each of which carries the version **twice**. `apps/web/src/lib/versionMirrors.test.ts` fails the
+  build if any of them drifts.
+- Add an entry to the top of `RECENT` in
+  [`apps/web/src/lib/releaseNotes/current.ts`](apps/web/src/lib/releaseNotes/current.ts);
+  `RECENT[0].version` **must equal** `version.json` (a test asserts this).
+- **That is the only release-notes file to edit.** The rest of `lib/releaseNotes/` is a summarisation layer:
+  older releases move to `archive.ts` under a named **epoch** in `epochs.ts`, and the release-notes page
+  opens on those epochs with every entry still listed verbatim one click in. Closing an epoch is its own
+  deliberate change, not part of shipping a release. `archive.ts` is loaded lazily by a single page and must
+  not be imported anywhere else - a test asserts the module graph, because nothing else would catch it.
 
 ### 3. Keep the docs current
 

--- a/README.md
+++ b/README.md
@@ -14,8 +14,10 @@ architecture plan for the full design.
 [docs/Runtime_Architecture.html](https://htmlpreview.github.io/?https://github.com/kenhayward/Diariz/blob/main/docs/Runtime_Architecture.html) has a live visual navigation of how Diariz fits together.
 
 Versioned per the rule in [CLAUDE.md](CLAUDE.md); the current version and per-release notes live in
-[`apps/web/src/lib/releases.ts`](apps/web/src/lib/releases.ts) (and [`/version.json`](version.json)) and on
-the in-app **Release Notes** page (`/release-notes`), reachable from **About** in the account menu.
+[`apps/web/src/lib/releaseNotes/`](apps/web/src/lib/releaseNotes) (and [`/version.json`](version.json)) and on
+the in-app **Release Notes** page (`/release-notes`), reachable from **About** in the account menu. That page
+opens on named **epochs** - a chapter per arc of work - with every individual release listed verbatim one
+click in.
 
 ## Features
 
@@ -166,9 +168,10 @@ ambient capture - see the [long-term roadmap](docs/long_term_roadmap.md).
 > **Keep this README current.** When a PR changes what the app does (a new feature, a stack change, or a
 > shipped roadmap item), update the **Features** table (one concise row) and **[docs/features.md](docs/features.md)**
 > (the full prose), plus the **Architecture** and **Roadmap** sections and the in-app About-box `CAPABILITIES`
-> table - all in the same PR, alongside the [`releases.ts`](apps/web/src/lib/releases.ts) entry required by
+> table - all in the same PR, alongside the
+> [`releaseNotes/current.ts`](apps/web/src/lib/releaseNotes/current.ts) entry required by
 > [CLAUDE.md](CLAUDE.md). (The version isn't repeated here on purpose - it lives in `version.json` /
-> `releases.ts` so it can't drift.)
+> `releaseNotes/current.ts` so it can't drift.)
 
 ## Licensing & commercial use
 

--- a/docs/Automatic_Slide_Capture.md
+++ b/docs/Automatic_Slide_Capture.md
@@ -1,8 +1,35 @@
 # Automatic Slide Capture - Feature Specification
 
-**Status:** specified, ready to implement (all open questions decided - see §12)
+**Status:** **shipped** - this document is now a record, not a plan.
 **Surface:** Electron desktop shell (`apps/desktop`) + web recorder (`apps/web`)
 **Server changes:** none
+
+Shipped as the two PRs §13.0 proposed, both on 2026-08-18:
+
+| | Version | PR | Headline |
+|---|---|---|---|
+| Phase A - icon capture controls | `0.226.2` | #543 | The capture buttons say why they are unavailable |
+| Phase B - auto-capture | `0.227.0` | #544 | Auto-capture takes the screenshots for you |
+
+**Read §14 and §15 before anything above them.** The B0 spike invalidated the original design mid-flight:
+detection moved from the shell to the renderer, driven by one warm `getDisplayMedia` stream. §15 explicitly
+supersedes §4.1-§4.5, §7.2 and Phase B of §13, and §15.2 lists what that deleted - `apps/desktop/src/slideDetector.js`,
+the `ageMs` IPC hint, the `paused` flag on `RecorderState` and `cropRectForSize` were **never built**. What
+exists instead is `apps/web/src/lib/slideDetector.ts` and `apps/web/src/lib/slideCapture.ts`.
+
+Two caveats for anyone using this as a reference:
+
+- The release checklists (§11, A5, B10) are a record of what was done at the time. They say "four mirrors"
+  (there are seven, all asserted by `apps/web/src/lib/versionMirrors.test.ts`) and point at
+  `apps/web/src/lib/releases.ts`, which since 0.260.0 is `apps/web/src/lib/releaseNotes/current.ts` with
+  `CAPABILITIES` in `apps/web/src/lib/appInfo.ts`. Follow `CLAUDE.md`, not these.
+- **§15.4 risk 3 is not true and may never have been.** It says `backgroundThrottling: false` "is already set
+  on the main window" and is load-bearing for capturing while minimised. It is not set anywhere in
+  `apps/desktop/` as of 0.262.0, and Electron's default throttles renderer timers on a hidden window. Whether
+  the 1 Hz auto-capture tick actually survives minimising is **unverified** - tracked as
+  [#684](https://github.com/kenhayward/Diariz/issues/684), which starts with reproducing it rather than
+  fixing it. Risk 2 (a screen-sharing indicator appearing while the stream is held) was recorded as
+  unmeasured and is not mentioned in the help article, so treat it as unmeasured still.
 
 ---
 

--- a/docs/Overall_Synopsis_of_Platform.md
+++ b/docs/Overall_Synopsis_of_Platform.md
@@ -17,9 +17,12 @@ transcript, and **chat across one or more transcripts** — all using an **OpenA
 configure** (per user or server-wide), so audio, transcripts, and the model stay on infrastructure you
 control.
 
-The canonical app version lives in `/version.json` (mirrored to the web/desktop `package.json`s and the API
-`<Version>`); the API reports it at `GET /health`, and user-facing release notes live in
-`apps/web/src/lib/releases.ts`.
+The canonical app version lives in `/version.json` (mirrored to the web/desktop/n8n `package.json`s, their
+three lock files, and the API `<Version>`); the API reports it at `GET /health`. User-facing release notes
+live in `apps/web/src/lib/releaseNotes/`: `current.ts` holds the releases since the last closed epoch and is
+the file each PR edits, `archive.ts` holds everything older, and `epochs.ts` names the curated spans the
+`/release-notes` page opens on. Both release-notes pages are lazy routes and nothing eager imports the
+module, which is what keeps ~170 KB gzip of history out of the initial bundle.
 
 ## Components
 

--- a/docs/Streaming_Capture_and_Live_Transcript.md
+++ b/docs/Streaming_Capture_and_Live_Transcript.md
@@ -631,13 +631,14 @@ PR 1 is worth shipping even if 2-4 never happen. PR 4 is small because §6.6 req
 
 ### Release checklist impact
 
-**This doc is a docs-only change**: no version bump, no `RELEASES` entry, no `CAPABILITIES` or README
+**This doc is a docs-only change**: no version bump, no `RECENT` entry, no `CAPABILITIES` or README
 edit. It does update `Overall_Synopsis_of_Platform.md` for the throughput correction in §4, which is a
 factual fix to an existing document rather than a new claim about the product.
 
-Each implementation PR does the full checklist in `CLAUDE.md`: version + seven mirrors, a `RELEASES`
-entry, and - because this adds a user-facing capability - the README Features row, the `docs/features.md`
-bullet and the About-box `CAPABILITIES` row in lockstep. PR 1 and PR 2 both touch
+Each implementation PR does the full checklist in `CLAUDE.md`: version + seven mirrors, a `RECENT[0]`
+entry in `apps/web/src/lib/releaseNotes/current.ts`, and - because this adds a user-facing capability - the
+README Features row, the `docs/features.md` bullet and the About-box `CAPABILITIES` row (in
+`apps/web/src/lib/appInfo.ts`) in lockstep. PR 1 and PR 2 both touch
 `Overall_Synopsis_of_Platform.md` (new stream, new contract, new hosted service) and `Data_Schema.md`
 (new entity, new column, new enum value).
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -2,7 +2,7 @@
 
 This is the detailed, prose feature list. The [README](../README.md) carries an at-a-glance
 two-column summary table and links here for the full detail. **Keep both in sync** (and the in-app
-About-box `CAPABILITIES` summary in [`apps/web/src/lib/releases.ts`](../apps/web/src/lib/releases.ts))
+About-box `CAPABILITIES` summary in [`apps/web/src/lib/appInfo.ts`](../apps/web/src/lib/appInfo.ts))
 when the app's scope changes - see [CLAUDE.md](../CLAUDE.md).
 
 - **Capture** audio from the browser microphone — **choose a specific input device** (the choice is

--- a/docs/superpowers/plans/2026-08-30-streaming-capture-phase-1.md
+++ b/docs/superpowers/plans/2026-08-30-streaming-capture-phase-1.md
@@ -488,9 +488,9 @@ Per CLAUDE.md. This is a user-facing feature, so items 1-7 all apply.
 
 `version.json` plus its seven mirrors: `apps/web/package.json`, `apps/desktop/package.json`, `src/Diariz.Api/Diariz.Api.csproj`, `integrations/n8n-nodes-diariz/package.json`, and the three `package-lock.json` files (web, desktop, n8n - **two `version` fields in each**). Edit the lock files by hand; do not regenerate.
 
-- [ ] **Step 2: `RELEASES[0]` in `apps/web/src/lib/releases.ts`**
+- [ ] **Step 2: `RECENT[0]` in `apps/web/src/lib/releaseNotes/current.ts`**
 
-Version, date, `pr`, headline, a PR-level prose summary, and `added`/`changed` bullets. The `pr` number is the issue-free case, so it is the PR's own number - confirm it rather than assuming.
+Version, date, `pr`, headline, a PR-level prose summary, and `added`/`changed` bullets. The `pr` number is the issue-free case, so it is the PR's own number - confirm it rather than assuming. `current.ts` is the only release-notes file to touch: since 0.260.0 the history is split, and `lib/releaseNotes/archive.ts` must not be imported by anything but the drill-down page.
 
 - [ ] **Step 3: The three feature surfaces, in lockstep**
 


### PR DESCRIPTION
## What

[PR #675](https://github.com/kenhayward/Diariz/pull/675) moved the release history from `apps/web/src/lib/releases.ts` to `apps/web/src/lib/releaseNotes/`, and `CAPABILITIES` to `apps/web/src/lib/appInfo.ts`. **Every doc that tells a contributor where to add a release entry still named the old file**, so following the checklist led to a path that does not exist. A session hit exactly that.

Nothing in the release notes themselves had drifted - I checked the invariants directly rather than assuming:

```
RECENT: 31   ARCHIVE: 468   SPINE: 468   EPOCHS: 30
version.json 0.262.0 == RECENT[0]        true
spine mirrors archive exactly            true
epochs tile the archive exactly          true
newest epoch `to` == ARCHIVE[0]          true
duplicate versions across both halves    0
```

## The corrections

`RELEASES[0]` -> `RECENT[0]`, and the path, across `CLAUDE.md`, `AGENTS.md`, `CONTRIBUTING.md`, `README.md`, `docs/features.md` and `docs/Overall_Synopsis_of_Platform.md`.

CLAUDE.md also gains what the split actually **is**, because the parts that bite are not discoverable from the file list: the five modules and which chunk each lands in, and the four invariants that are invisible when broken.

- Only `pages/EpochDetail.tsx` may import `./archive` - adding that import to an eager module type-checks, renders correctly and passes every other test while putting ~170 KB gzip back on every page load.
- The epoch ranges must **tile** the archive. A release between two epochs is never listed: no 404, no error.
- `ARCHIVED_SPINE` mirrors `ARCHIVE` exactly; an epoch stores no count or date span, because a stored copy would be a second derivation agreeing only by luck.
- `current` is a reserved epoch id.

Plus the point the whole design rests on: **summarisation is additive.** An epoch is a chapter heading over an intact archive, never a rewrite of it. If you find yourself editing a `Release` entry to make an epoch summary read better, the direction is backwards. Closing an epoch is called out as a deliberate separate change, with the three mechanical steps and a note to ask rather than do it unprompted - it is a judgement about narrative, and the 80-entry test is a safety net, not the trigger.

## Found on the way

- **`CONTRIBUTING.md` and `Overall_Synopsis` listed four version mirrors.** There are seven, all asserted by `versionMirrors.test.ts` - I verified that against the test rather than trusting CLAUDE.md.
- **Both live streaming-capture plans carried the dead path in their own release checklists**, which the next implementer would have followed. Fixed. The ~110 historical plans and specs under `docs/superpowers/` keep it deliberately: they are records of executed work, not instructions, and rewriting them would falsify the record.
- **`docs/Automatic_Slide_Capture.md` still read "specified, ready to implement"** for a feature that shipped in `0.226.2` / `0.227.0` (#543, #544) - inviting someone to build it again. Its header now records what shipped, and warns that §14-§15 supersede the design above them: the B0 spike moved detection to the renderer, so `slideDetector.js`, the `ageMs` hint, the `paused` flag and `cropRectForSize` were **never built**. I confirmed each of those is absent and that `slideDetector.ts` / `slideCapture.ts` exist instead.

## One finding, filed not fixed

Writing that header surfaced a possible defect. §15.4 risk 3 asserts `backgroundThrottling: false` "is already set on the main window" and is load-bearing for capturing while minimised. **It is not set anywhere in `apps/desktop/`** - all four `webPreferences` blocks in `main.js` list `preload`, `contextIsolation`, `sandbox`, `nodeIntegration` and nothing else. The auto-capture loop is a plain `setInterval` at 1 Hz in the renderer, which is what Chromium throttles to ~1/min when hidden.

Raised as #684, explicitly **not reproduced** - it leads with how to check, and can be closed as a false alarm. This PR does not fix it and does not close it; it only stops the spec stating as settled fact something that is not in the code.

## Release

**Docs-only: no version bump and no `RECENT` entry** (checklist items 1-3 skipped, per CLAUDE.md). Items 4-7 are the subject of the change rather than a side effect - README Features, `docs/features.md`, `Overall_Synopsis` and `Data_Schema` are all left accurate; no feature row changed because no capability changed.

**Deployment surface: neither.** No desktop release, no server redeploy - markdown only, no file under `apps/` or `src/` is touched.

## Verification

- All 9 files are markdown; `git diff --stat` confirms nothing under `apps/` or `src/`.
- Every relative markdown link in the edited files resolves (checked programmatically; the only three that do not are pre-existing and untouched - a URL-encoded space, an API route, an example path).
- Line endings preserved as CRLF in all 9, zero lone LFs - this repo has been bitten by that before.
- Every path the docs now name was confirmed to exist on disk.
- No stale `lib/releases.ts` or `RELEASES` reference remains in any live doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
