### PR TITLE
Correct the slide-capture throttling risk, which was false twice over

### DIFF
--- a/docs/Automatic_Slide_Capture.md
+++ b/docs/Automatic_Slide_Capture.md
@@ -23,13 +23,14 @@ Two caveats for anyone using this as a reference:
   (there are seven, all asserted by `apps/web/src/lib/versionMirrors.test.ts`) and point at
   `apps/web/src/lib/releases.ts`, which since 0.260.0 is `apps/web/src/lib/releaseNotes/current.ts` with
   `CAPABILITIES` in `apps/web/src/lib/appInfo.ts`. Follow `CLAUDE.md`, not these.
-- **§15.4 risk 3 is not true and may never have been.** It says `backgroundThrottling: false` "is already set
-  on the main window" and is load-bearing for capturing while minimised. It is not set anywhere in
-  `apps/desktop/` as of 0.262.0, and Electron's default throttles renderer timers on a hidden window. Whether
-  the 1 Hz auto-capture tick actually survives minimising is **unverified** - tracked as
-  [#684](https://github.com/kenhayward/Diariz/issues/684), which starts with reproducing it rather than
-  fixing it. Risk 2 (a screen-sharing indicator appearing while the stream is held) was recorded as
-  unmeasured and is not mentioned in the help article, so treat it as unmeasured still.
+- **§15.4 risk 3 was wrong twice over, and is now corrected in place.** It said `backgroundThrottling: false`
+  "is already set on the main window" and is load-bearing for capturing while minimised. It is **not set**
+  anywhere in `apps/desktop/`, and it is **not needed**: measured on Electron 43 / Windows 11, an active
+  media capture exempts the page from timer throttling entirely, and auto-capture only ever runs during a
+  recording. Investigated and closed as a false alarm in
+  [#684](https://github.com/kenhayward/Diariz/issues/684), which carries the measurements. Risk 2 (a
+  screen-sharing indicator appearing while the stream is held) was recorded as unmeasured and is not
+  mentioned in the help article, so treat it as unmeasured still.
 
 ---
 
@@ -910,8 +911,12 @@ so that "no change detected" could be distinguished from "the capture froze":
 | restored | +5.00 s | 6/8 | live |
 | hidden (`win.hide()`, separate run) | +3.02 s | 2/5 | live |
 
-The stream keeps delivering in every state. `backgroundThrottling: false` is set on the window, and
-should be treated as load-bearing rather than incidental.
+The stream keeps delivering in every state. The reason was misattributed here: `backgroundThrottling:
+false` is **not** set on the window and never has been. What keeps the tick running is that an **active
+media capture exempts the page from throttling** - and auto-capture can only run during a recording, which
+always holds one. Measured separately in #684: a bare hidden window drops to 1 tick/min after about a
+minute, while the same window holding a microphone stream and MediaRecorder kept 419 of 420 ticks across
+seven minutes minimised, and 179 of 180 hidden to the tray.
 
 **Still unmeasured:** whether Windows shows a persistent screen-sharing indicator while the stream is
 held, and the behaviour on macOS (where Screen Recording permission and its menu-bar indicator apply).
@@ -992,5 +997,11 @@ B0 and B1 are done. What remains:
 2. **A screen-sharing indicator** may appear while the stream is held (unmeasured). If Windows or macOS
    shows one for the whole meeting, that is a user-visible surprise and needs to be in the help text
    rather than discovered.
-3. **`backgroundThrottling: false`** is load-bearing for the minimised case. It is already set on the
-   main window; it must not be removed, and that deserves a comment where it is set.
+3. ~~**`backgroundThrottling: false`** is load-bearing for the minimised case. It is already set on the
+   main window; it must not be removed, and that deserves a comment where it is set.~~ **Not a risk, and
+   the premise was false** - see #684. The setting is not present anywhere in `apps/desktop/`, and adding
+   it would buy nothing: an active media capture already exempts the page, and auto-capture cannot run
+   without a recording. It would also cost something, since it disables throttling for the whole life of
+   the window, including the long stretches when Diariz sits in the tray doing nothing. The risk was
+   reasoned from Chromium's documented behaviour without checking whether the app's own always-on
+   recording exempts it.


### PR DESCRIPTION
## What

#684 asked whether auto-capture stalls while the desktop window is minimised, because `docs/Automatic_Slide_Capture.md` §15.4 risk 3 claimed `backgroundThrottling: false` was "already set on the main window" and load-bearing - and it is not set anywhere in `apps/desktop/`.

**Checked by measuring. It is a false alarm**, and the spec was wrong in both halves. #684 is closed as not planned; this PR corrects the document so the next reader is not sent after it again.

## The measurements

A minimal Electron 43 app mirroring the main window's `webPreferences`, running a 1 Hz `setInterval` and recording every tick:

| Window state | Active media | Hidden for | Ticks | Expected | Result |
|---|---|---|---|---|---|
| `minimize()` | none | 20s | 10 | 20 | throttled ~2x |
| `minimize()` | none, **`backgroundThrottling:false`** | 20s | 20 | 20 | not throttled |
| `minimize()` | none | 7min | **65** | 420 | **1 tick/min after minute 1** |
| `minimize()` | mic + MediaRecorder | 30s | 30 | 30 | not throttled |
| `minimize()` | mic + MediaRecorder | 7min | **419** | 420 | **not throttled** |
| `hide()` (close to tray) | mic + MediaRecorder | 3min | **179** | 180 | **not throttled** |

**The concern was well-founded in principle.** A bare hidden window is throttled harder than the risk assumed - intensive throttling starts after about **one minute**, not the five Chromium documents, and collapses a 1 Hz sampler to one tick per minute (`59, 1, 1, 1, 1, 1, 1`). At that rate auto-capture would need a slide held for three minutes to clear the detector's consecutive-stable-samples bar, so it would have captured essentially nothing.

**It is simply never reachable here.** An active media capture exempts the page completely, and the exemption does not decay. Auto-capture cannot run without a recording, and a recording always holds a live microphone stream feeding a MediaRecorder.

## Three corrections, not one

Searching for the claim turned up a third site I had missed when I first flagged this:

1. **§15.4 risk 3** - struck through, with what actually happens and why.
2. **§14 (B0 findings)** - asserted the same false premise *while explaining its own measurements*. Its table showed the stream delivering in every window state, and credited a setting that does not exist rather than the media exemption. The observation was right; the explanation was wrong.
3. **The status header** - previously said the risk was unverified and pointed at the open issue; now records the outcome.

## Why not just add the setting

It looks like a free safety measure and is not. `backgroundThrottling: false` disables throttling for the entire life of the window, including the long stretches when Diariz sits in the tray with no recording - a battery and CPU cost in exchange for protection against a state the feature cannot be in.

## Caveats

- Measured on **Windows 11 / Electron 43**, which is what the desktop app ships. **Not tested on macOS** - the exemption is Chromium behaviour rather than platform-specific, so it should hold, but I have not confirmed it.
- The probe held a microphone stream and MediaRecorder. Auto-capture also holds a `getDisplayMedia` stream, which would only strengthen the exemption.
- This measures the mechanism, not auto-capture end to end. If captures are ever seen stopping while minimised, the timer is no longer the suspect.

## Release

**Docs-only: no version bump and no `RECENT` entry** (checklist items 1-3 skipped, per CLAUDE.md). Items 4-7 are unaffected - nothing about what the app does has changed, and this file is not one of the feature inventories.

**Deployment surface: neither.** One markdown file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
