### PR TITLE
Build the desktop app in CI, without gating on it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,53 @@ jobs:
         working-directory: apps/desktop
         run: node --test "src/**/*.test.js"
 
+  desktop-build:
+    name: Desktop build (electron-builder)
+    # NOT in the Main_Rules required set, so it reports without gating a merge. It is deliberately a
+    # normal job rather than `continue-on-error: true`: a job that always reports success cannot tell
+    # you anything, and this repo has already paid for that once - see the note on the `desktop` job
+    # above, where a coverage run that could not fail let an ESM-only electron-store bump reach a green
+    # PR with its tests failing inside the log.
+    #
+    # What this covers and what it does not. `apps/desktop` is tested but was never BUILT anywhere
+    # except a `v*` release tag, so the first thing to discover that an Electron major broke packaging
+    # was whoever cut the installer. This packages the app for real - electron download, the config,
+    # asar, and the Outlook reader landing in extraResources - and stops there. It is a packaging
+    # check: it says nothing about whether the tray, the loopback audio capture or the updater still
+    # work at runtime, which still needs a human with an installer.
+    #
+    # windows-latest rather than ubuntu, because that is what actually ships: the win block is the one
+    # with extraResources, and the Outlook reader is a win-x64 exe. `--dir` stops at the unpacked
+    # directory, so there is no NSIS step and nothing to sign.
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '22'
+          cache: npm
+          cache-dependency-path: apps/desktop/package-lock.json
+      # The Outlook reader is a self-contained .NET exe that electron-builder copies in via
+      # extraResources, so packaging fails without it having been published first.
+      - uses: actions/setup-dotnet@v6
+        with:
+          dotnet-version: '10.0.x'
+      - name: Install
+        working-directory: apps/desktop
+        run: npm ci
+      - name: Package (unpacked - no installer, no signing)
+        working-directory: apps/desktop
+        run: npm run dist:dir
+      # electron-builder exiting 0 is not proof it produced anything. Assert the app exists, so a
+      # config change that quietly stops emitting one fails here rather than at the next release.
+      - name: Verify an app was actually produced
+        working-directory: apps/desktop
+        shell: pwsh
+        run: |
+          $exe = "release/win-unpacked/Diariz.exe"
+          if (-not (Test-Path $exe)) { throw "electron-builder reported success but produced no app at $exe" }
+          "Packaged app: {0:N1} MB" -f ((Get-Item $exe).Length / 1MB)
+
   locale-gate:
     name: Locale single-language gate
     runs-on: ubuntu-latest

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -15,6 +15,7 @@
     "start": "electron .",
     "test": "node --test \"src/**/*.test.js\"",
     "dist": "npm run build:outlook && electron-builder --config electron-builder.config.js",
+    "dist:dir": "npm run build:outlook && electron-builder --config electron-builder.config.js --dir",
     "publish": "npm run build:outlook && electron-builder --config electron-builder.config.js --publish always",
     "build:outlook": "dotnet publish native/Diariz.OutlookReader -c Release -o native/publish"
   },


### PR DESCRIPTION
`apps/desktop` is tested but was never **built** anywhere except a `v*` release tag, so the first thing to
discover that a dependency broke packaging was whoever cut the installer. That is what made #692
(Electron 43 -> 44) awkward to judge: sixteen green checks, not one of which had ever run electron-builder.

## What it does

Packages the app for real - electron download, the config, asar, and the Outlook reader landing in
`extraResources` - and stops at the unpacked directory. No NSIS step, nothing to sign.

`windows-latest` rather than ubuntu, because that is what ships: the `win` block is the one carrying
`extraResources`, and the Outlook reader is a win-x64 exe. The job publishes the reader first (setup-dotnet
+ `build:outlook`), since packaging fails without it.

The command lives in a new `dist:dir` npm script rather than inline YAML, so a developer runs exactly what
CI runs.

## Not gating, and not `continue-on-error` either

It is **not** in the `Main_Rules` required set, so it reports without blocking a merge - as asked.

It is also deliberately **not** `continue-on-error: true`, which would be the other way to make it
non-gating. A job that always reports success cannot tell you anything, and this repo has already paid for
that once: the comment on the existing `desktop` job records a coverage run that could not fail letting an
ESM-only `electron-store` bump reach a green PR with its tests failing inside the log. So a broken build
here shows red - it just does not stop you merging.

If you later want it gating, it can be added to the ruleset with no trap: it has no `paths` filter, so it
runs on every PR and can never sit "expected - waiting for status" on an unrelated change.

## What it does not cover

It is a **packaging** check. It says nothing about whether the tray, the loopback audio capture
(`setDisplayMediaRequestHandler`, which serves both Windows loopback and macOS ScreenCaptureKit) or the
updater still work at runtime. Those need a human with an installer. This turns "does an Electron bump even
package" from a leap of faith into an ordinary check, and no more than that.

## Verification

Ran it rather than trusting the YAML - `npm run dist:dir` on this branch:

```
• packaging       platform=win32 arch=x64 electron=43.0.0 appOutDir=release\win-unpacked
Packaged app: 224.8 MB
Outlook reader present: True
```

electron-builder exiting 0 is not proof it produced anything, so the job asserts the app exists rather than
trusting the exit code - the same shape as the release workflow's existing reader check. Confirmed the guard
can fail, by pointing it at a path that does not exist:

```
guard fired: electron-builder reported success but produced no app at release/win-unpacked/NoSuchApp.exe
```

The workflow parses, and the job registers alongside the existing seven.

## Release checklist

**CI-only, so no version bump and no release entry** - nothing user-facing changes and nothing is released.
The only non-workflow edit is an added npm script; `versionMirrors.test.ts` still passes (8/8), as the
version field is untouched. README, `docs/features.md`, the architecture and schema docs are all unaffected.

No issue: a CI enhancement is a chore, not a user-visible fault.

## Deployment surface

**Neither.** No desktop release, no server redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
