### PR TITLE
Correct the 0.266.1 release entry's PR number

### DIFF
--- a/apps/web/src/lib/releaseNotes/archive.ts
+++ b/apps/web/src/lib/releaseNotes/archive.ts
@@ -26,7 +26,7 @@ export const ARCHIVE: Release[] = [
   {
     version: "0.266.1",
     date: "2026-09-02",
-    pr: 734,
+    pr: 735,
     headline: "Actions taken just after a restart no longer fail",
     summary:
       "An action taken just after Diariz restarts could come back as a bare failure, then work perfectly on a second try - most visibly when re-running a transcription immediately after an update.\n\nDiariz prepares its database when it starts. If the database itself was still coming up at that exact moment, Diariz gave up rather than waiting - on the restart that prompted this, it was nine tenths of a second too early. It restarted itself a few seconds later and everything was fine, so it looked like a glitch, but anything you did in that gap simply failed.\n\nIt now waits for the database instead of giving up. Nothing was ever lost when this happened - the transcription in question had already finished successfully - but the error was real and is gone.",


### PR DESCRIPTION
The **0.266.1** release entry recorded `pr: 734`. That is a different PR - the About-box link work, released
as 0.266.2 - so two entries pointed at the same one, and the older of them at something unrelated to what it
describes.

| Version | Headline | Recorded | Actual |
|---|---|---|---|
| 0.266.2 | Help and the release notes get a window of their own | 734 | 734 |
| 0.266.1 | Actions taken just after a restart no longer fail | **734** | **735** |

## Confirmed, not inferred

The entry was introduced by `ba36aa8b` ("fix(api): wait for Postgres at startup instead of dying on it"),
which reached `main` through **#735**. Traced with `git log -S` on the headline rather than matched by
eye.

The file is `archive.ts` rather than `current.ts` because #741 archived that release earlier today.

## Why it happened, and why nothing caught it

This is the trap the `pr:` field sets by design: it has to be written **before** `gh pr create` exists to
report the real number, so it is always a guess - and 734 was already taken by the time this one was
written. Nothing compares the number to anything, so it cannot be caught by a test as things stand.

The same trap produced the wrong number on the 0.265.3 entry earlier today (it points at issue #718 rather
than PR #714). That one was left alone deliberately; this one is worse because it is a **duplicate**, and
the release-notes page will link two different releases to the same PR.

I swept the whole archive for the same fault while here: **519 entries, no other PR number used twice.**

## No version bump

Matching how the two previous corrections of this kind were shipped - `3feb1b8f` and `d753b60e` - both
one-line edits to the release data with no bump and no release entry. Nothing about the app changes, and a
release note announcing a corrected footnote on an older release note would be noise.

Release-notes tests 81/81, `npm run build` clean.

## Deployment surface

**Server redeploy** whenever convenient - it only changes what the release-notes page links to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
